### PR TITLE
Fix CI for new repo

### DIFF
--- a/.github/workflows/weekly_dependencies.yml
+++ b/.github/workflows/weekly_dependencies.yml
@@ -1,4 +1,4 @@
-name: Aegis Dockerhub image build/push
+name: Weekly Dependency environment build
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Aegis 
-Aegis is a Monte-Carlo particle tracking tool for calculating power deposition loads (inspired by the SMARDDA FORTRAN code used for the same case) due to particles on surface accurate representations of fusion plasma First Wall Shielding. Makes use of DAGMC/Double-Down as a ray tracing tool that will be used to calculate neutral particle trajectories. Charged particle trajectories will eventually be calculated from field-line tracing and solving of the ODEs which govern these particles trajectories. 
+Aegis is a Monte-Carlo particle tracking tool for calculating power deposition loads due to particles on surface accurate representations of fusion plasma First Wall Shielding. Aegis is part of Aurora-Multiphysics simulation code group. It makes use of DAGMC/Double-Down as a ray tracing tool that will be used to calculate neutral particle trajectories. Charged particle trajectories are tracked as following magnetic field lines calculated from toroidal flux surface data.
 
 The following dependancies are **required**:
 - **Embree v3.6.1** (Intel Embree Ray Tracer)  

--- a/docker/limited_build/Dockerfile
+++ b/docker/limited_build/Dockerfile
@@ -7,7 +7,7 @@ ARG WORKDIR="opt"
 RUN cd /$WORKDIR && \
     mkdir temp && \
     cd temp && \
-    git clone https://github.com/Waqar-ukaea/aegis.git && \
+    git clone https://github.com/aurora-multiphysics/aegis.git && \
     cd aegis && \
     cmake -DDAGMC_DIR=/$WORKDIR/dagmc_bld/DAGMC/lib/cmake/dagmc/ && \
 

--- a/docker/weekly_build/Dockerfile
+++ b/docker/weekly_build/Dockerfile
@@ -121,4 +121,17 @@ RUN cd /$WORKDIR/ && \
     cmake ../ && \ 
     make && \
     make install
+
+# Install Catch2
+RUN cd /$WORKDIR/ && \
+    mkdir Catch2 && \
+    git clone https://github.com/catchorg/Catch2.git && \
+    cd Catch2 && \
+    mkdir build && \
+    cd build && \
+    cmake ../ && \
+    make && \
+    make install 
+
+   
     


### PR DESCRIPTION
- Fixed Aegis CI to work in new repo location (aurora-mulitphysics/aegis). 
- Also added Catch2 to weekly dependency build for Docker and CI. 
- Will eventually be switching gtest over to Catch2