### PR TITLE
Fix issue#3 and achieved (close-to) agreement with one SMARDDA test case

### DIFF
--- a/runSettings.txt
+++ b/runSettings.txt
@@ -1,23 +1,22 @@
 # String Valued Aegis Run Parameters
 DAGMC_input [s] inres1.h5m
 VTK_input [s] inres1.stl
-ray_qry [s] exps/exps00010000.qry
 runcase [s] eqdsk
 launchPos [s] fixed
-trace [s] no
+trace [s] yes
 eqdsk_file [s] eqdsk/EQ3.eqdsk 
 
 # Integer Valued Aegis Run Parameters
 cenopt [i] 2
 number_of_rays_launched_per_tri [i] 5
-nTrack [i] 10000
+nTrack [i] 100000
 
 # Double Valued Aegis Run Parameters
 dsTrack [d] 0.05
 Psol [d] 7.5e+06
 lambda_q [d] 0.012
 psiref [d] -2.1628794
-rOutrBdry [d] 8.17385
-
+rOutrBdry [d] 8.07385
+rmove [d] -0.006
 # Vector<int> Valued Aegis Run Parameters
-surfs [v] 479
+surfs [v] 0

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -59,14 +59,6 @@ using moab::DagMC;
 using moab::OrientedBoxTreeTool;
 moab::DagMC* DAG;
 
-void next_pt(double prev_pt[3], double origin[3], double next_surf_dist,
-                          double dir[3], std::ofstream &ray_intersect);
-double dot_product(double vector_a[], double vector_b[]);
-double dot_product(std::vector<double> vector_a, std::vector<double> vector_b);
-void reflect(double dir[3], double prev_dir[3], EntityHandle next_surf);
-double * vecNorm(double vector[3]);
-
-
 // LOG macros
 
 //LOG_TRACE << "this is a trace message";             ***WRITTEN OUT TO LOGFILE***
@@ -76,8 +68,6 @@ double * vecNorm(double vector[3]);
 //LOG_FATAL << "this is a fatal error message";       ***WRITTEN OUT TO CONSOLE AND LOGFILE***
 
 int main() {
-
-
 
   clock_t start = clock();
   settings settings;
@@ -129,9 +119,6 @@ int main() {
   double prev_surf_dist; // previous next_surf_dist before the next ray_fire call
   DagMC::RayHistory history; // initialise RayHistory object
   EntityHandle vol_h = DAG->entity_by_index(3, 1);
-
-
-
 
   // --------------------------------------------------------------------------------------------------------
 
@@ -277,7 +264,7 @@ int main() {
     std::string particleTrace = settings.sValues["trace"];
     double rOutrBdry = settings.dValues["rOutrBdry"];
     LOG_WARNING << "rOutrBdry (from input file) = " << rOutrBdry;
-    // LOOP OVER FACETS OF INTEREST IN SURFACE s -----------------------------------------------------------    
+    // LOOP OVER FACETS OF INTEREST IN SURFACE s ----------------------------------------------------------- 
     for (auto i:targetFacets)
     {
       //DAG->moab_instance()->list_entity(s);
@@ -330,11 +317,10 @@ int main() {
       std::string forwards = "forwards";
       polarPos = coordTfm::cart_to_polar(particle.launchPos, forwards);
       aegisVTK.arrays["B_field"]->InsertNextTuple3(particle.BfieldXYZ[0], particle.BfieldXYZ[1], particle.BfieldXYZ[2]);
-      Bn = dot_product(particle.BfieldXYZ,Tri.unitNormal);
+      Bn = Tri.dot_product(particle.BfieldXYZ); // dot product between triangle normal and bfield
       
       // CALCULATING Q at surface 
       double psi;
-
       std::vector<double> temp;
       temp = coordTfm::cart_to_polar(particle.launchPos, "forwards");
       temp = coordTfm::polar_to_flux(temp, "forwards", EquData);
@@ -561,21 +547,5 @@ int main() {
   std::cout << "------------------------------------------------------" << std::endl;
 
   return 0;
-}
-
-
-
-double dot_product(double vector_a[], double vector_b[]){
-   double product = 0;
-   for (int i = 0; i < 3; i++)
-   product = product + vector_a[i] * vector_b[i];
-   return product;
-}
-
-double dot_product(std::vector<double> vector_a, std::vector<double> vector_b){
-   double product = 0;
-   for (int i = 0; i < 3; i++)
-   product = product + vector_a[i] * vector_b[i];
-   return product;
 }
 

--- a/src/aegis_lib/integrator.cpp
+++ b/src/aegis_lib/integrator.cpp
@@ -175,11 +175,3 @@ void surfaceIntegrator::piecewise_multilinear_out(std::unordered_map<moab::Entit
 
 
 }
-
-
-// double surfaceIntegrator::calculate_q()
-// {
-//   double q; // power deposited on current cell calculated from eich formula
-
-
-// }

--- a/src/aegis_lib/particle.cpp
+++ b/src/aegis_lib/particle.cpp
@@ -34,11 +34,11 @@ void particleBase::set_pos(double newPosition[]) // overload set_pos() for C-sty
   this->pos = tempVector; // set the new position  
 }
 
-bool particleBase::check_if_in_bfield(equData &EquData)
+void particleBase::check_if_in_bfield(equData &EquData)
 {
   std::vector<double> currentBfield = EquData.b_field(this->pos, "cart");
-  if (currentBfield.empty()) {return true;}
-  else {return false;}
+  if (currentBfield.empty()) {this->outOfBounds = true;}
+  else {this->outOfBounds = false;}
 }
 
 std::vector<double> particleBase::get_pos(std::string coordType) // return STL vector of current particle position
@@ -61,10 +61,14 @@ std::vector<double> particleBase::get_pos(std::string coordType) // return STL v
 
 void particleBase::set_dir(equData &EquData) // Set unit direction vector along cartesian magnetic field vector
 {
+  this->check_if_in_bfield(EquData);
+  if (this->outOfBounds) {return;} // exit function early if out of bounds
+
   double norm; // normalisation constant for magnetic field
   std::vector<double> normB(3); // normalised magnetic field
   std::vector<double> polarPos = coordTfm::cart_to_polar(this->pos, "forwards"); // polar position
-  std::vector<double> magn = EquData.b_field(this->pos, "cart"); // magnetic field
+  std::vector<double> magn(3); 
+  magn = EquData.b_field(this->pos, "cart"); // magnetic field
   this->Bfield = magn;
   magn = EquData.b_field_cart(magn, polarPos[2], 0);
   this->BfieldXYZ = magn;

--- a/src/aegis_lib/particle.h
+++ b/src/aegis_lib/particle.h
@@ -28,14 +28,14 @@ class particleBase
   std::vector<double> pos; // current position of particle 
   std::vector<double> launchPos; // initial starting position of particle on triangle
   int atMidplane; // 0 == Not at midplane; 1 == At Inner-Midplane; 2 == At Outer-Midplane  
-
+  bool outOfBounds = false;
 
   void set_pos(std::vector<double> newPosition); // set new particle position
   void set_pos(double newPosition[]); // overload for C-style array
   std::vector<double> get_pos(std::string coordType); // return STL vector of the current position
   void set_dir(equData &EquData); // set unit drection vector and Bfield at current position
   std::vector<double> get_dir(std::string coordType); // return STL vector of unit direction
-  bool check_if_in_bfield(equData &Equdata); // check if in magnetic field
+  void check_if_in_bfield(equData &Equdata); // check if in magnetic field
   void align_dir_to_surf(double Bn); // align particle dir to surface normal
   void update_vectors(double distanceTravelled); // update position  
   void update_vectors(double distanceTravelled, equData &EquData); // overload to update dir as well

--- a/src/aegis_lib/source.cpp
+++ b/src/aegis_lib/source.cpp
@@ -176,7 +176,7 @@ double triSource::dot_product(std::vector<double> externalVector)
   double product = 0;
   for (int i; i<3; i++)
   {
-    product = product + externalVector[i]*this->normal[i];
+    product = product + externalVector[i]*this->unitNormal[i];
   }
   return product;
 }

--- a/src/aegis_lib/source.cpp
+++ b/src/aegis_lib/source.cpp
@@ -6,36 +6,6 @@
 #include "source.h"
 
 
-
-//create_source()
-
-// OpenMC has function IndependantSource() that generates an independant source
-// It appears to do a number of different things:
-// 1) Check particle type 
-// 2) Check source strength - relevant if multiple sources present (i.e to pick one source over the other)
-// 3) Check for external source file
-// 4) Determine the spatial distribution of the source (if None then create point source)
-// 5) Determine the angular distribution (if None create isotropic source)
-// 6) Determine the source energy disitribution
-// 7) Determine the source time distribution (defualt to constant time T=0)
-
-// 7 Things that make up the definition of a radiation source. 
-
-// First attempt could be something like:
-// 1) Neutron
-// 2) 1.0
-// 3) No external Source file
-// 4) Spherical dsitribution 
-// 5) Isotropic
-// 6) OpenMC defualt energy distribution
-// 7) Constant time T=0
-
-// Next steps: 
-// Create a particleType class 
-// Create a source class
-// 
-
-
 pointSource::pointSource(std::vector<double> xyz)
 {
   for (int i=0; i<xyz.size(); i++)
@@ -199,4 +169,14 @@ void triSource::dagmcInstance(moab::DagMC* DAG)
 {
   DAGInstance = DAG;
   DAGInstance->write_mesh("dag.out", 1);
+}
+
+double triSource::dot_product(std::vector<double> externalVector) 
+{
+  double product = 0;
+  for (int i; i<3; i++)
+  {
+    product = product + externalVector[i]*this->normal[i];
+  }
+  return product;
 }

--- a/src/aegis_lib/source.h
+++ b/src/aegis_lib/source.h
@@ -11,33 +11,6 @@
 #include "moab/Interface.hpp"
 #include <moab/OrientedBoxTreeTool.hpp>
 
-//create_source()
-
-// OpenMC has function IndependantSource() that generates an independant source
-// It appears to do a number of different things:
-// 1) Check particle type 
-// 2) Check source strength - relevant if multiple sources present (i.e to pick one source over the other)
-// 3) Check for external source file
-// 4) Determine the spatial distribution of the source (if None then create point source)
-// 5) Determine the angular distribution (if None create isotropic source)
-// 6) Determine the source energy disitribution
-// 7) Determine the source time distribution (defualt to constant time T=0)
-
-// 7 Things that make up the definition of a radiation source. 
-
-// First attempt could be something like:
-// 1) Neutron
-// 2) 1.0
-// 3) No external Source file
-// 4) Spherical dsitribution 
-// 5) Isotropic
-// 6) OpenMC defualt energy distribution
-// 7) Constant time T=0
-
-// Next steps: 
-// Create a particleType class 
-// Create a source class
-// 
 
 
 using moab::DagMC;
@@ -94,6 +67,7 @@ class triSource
   void dagmcInstance(moab::DagMC* DAG); 
   std::vector<double> random_pt();
   std::vector<double> centroid();
+  double dot_product(std::vector<double> externalVector);
 
 
 

--- a/test/Data/logfile.log
+++ b/test/Data/logfile.log
@@ -1,56 +1,62 @@
-0000001 | 2023-12-06, 14:50:27.692025 [trace] - -----equData.read_eqdsk()-----
-0000002 | 2023-12-06, 14:50:27.692446 [warning] - eqdsk file to be read - test.eqdsk
-0000003 | 2023-12-06, 14:50:27.692569 [warning] - Number of grid points in R (nw) = 65
-0000004 | 2023-12-06, 14:50:27.692591 [warning] - Number of grid points in Z (nh) = 129
-0000005 | 2023-12-06, 14:50:27.692673 [warning] - Geometry parameters from EFIT:
-0000006 | 2023-12-06, 14:50:27.692693 [warning] - Domain size in R eqdsk.rdim 6
-0000007 | 2023-12-06, 14:50:27.692730 [warning] - Domain size in Z eqdsk.zdim 12
-0000008 | 2023-12-06, 14:50:27.692747 [warning] - R at centre 6.2
-0000009 | 2023-12-06, 14:50:27.692763 [warning] - Domain start in R eqdsk.rgrid 3
-0000010 | 2023-12-06, 14:50:27.692779 [warning] - Domain centre in Z eqdsk.zmid 0
-0000011 | 2023-12-06, 14:50:27.692796 [warning] - Plasma parameters from EFIT:
-0000012 | 2023-12-06, 14:50:27.692811 [warning] - B at rcentre 5.3
-0000013 | 2023-12-06, 14:50:27.692828 [warning] - Flux at centre ssimag1 12.9719
-0000014 | 2023-12-06, 14:50:27.692844 [warning] - Flux at boundary ssibry1 2.51614
-0000015 | 2023-12-06, 14:50:27.692861 [warning] - Plasma centre in R eqdsk.rmaxis 6.37753
-0000016 | 2023-12-06, 14:50:27.692878 [warning] - Plasma centre in Z eqdsk.zmaxis -0.242403
-0000017 | 2023-12-06, 14:50:27.692894 [warning] - Plasma current 1.48039e+07
-0000018 | 2023-12-06, 14:50:27.692919 [trace] - -----equData.read_array()-----
-0000019 | 2023-12-06, 14:50:27.692940 [warning] - Reading eqdsk.fpol values...
-0000020 | 2023-12-06, 14:50:27.693009 [warning] - Number of eqdsk.fpol values read = 65
-0000021 | 2023-12-06, 14:50:27.693029 [trace] - -----equData.read_array()-----
-0000022 | 2023-12-06, 14:50:27.693039 [warning] - Reading eqdsk.pres values...
-0000023 | 2023-12-06, 14:50:27.693090 [warning] - Number of eqdsk.pres values read = 65
-0000024 | 2023-12-06, 14:50:27.693106 [trace] - -----equData.read_array()-----
-0000025 | 2023-12-06, 14:50:27.693123 [warning] - Reading eqdsk.ffprime values...
-0000026 | 2023-12-06, 14:50:27.693178 [warning] - Number of eqdsk.ffprime values read = 65
-0000027 | 2023-12-06, 14:50:27.693195 [trace] - -----equData.read_array()-----
-0000028 | 2023-12-06, 14:50:27.693207 [warning] - Reading eqdsk.pprime values...
-0000029 | 2023-12-06, 14:50:27.693264 [warning] - Number of eqdsk.pprime values read = 65
-0000030 | 2023-12-06, 14:50:27.693282 [trace] - -----equData.read_2darray()-----
-0000031 | 2023-12-06, 14:50:27.693412 [warning] - Reading Psi(R,Z) values...
-0000032 | 2023-12-06, 14:50:27.698832 [warning] - Number of Psi(R,Z) values read = 8385
-0000033 | 2023-12-06, 14:50:27.698911 [trace] - -----equData.read_array()-----
-0000034 | 2023-12-06, 14:50:27.698932 [warning] - Reading eqdsk.qpsi values...
-0000035 | 2023-12-06, 14:50:27.699010 [warning] - Number of eqdsk.qpsi values read = 65
-0000036 | 2023-12-06, 14:50:27.699034 [warning] - Number of boundary points 89
-0000037 | 2023-12-06, 14:50:27.699052 [warning] - Number of limiter points 57
-0000038 | 2023-12-06, 14:50:27.699083 [warning] - Reading eqdsk.rbdry and eqdsk.zbdry...
-0000039 | 2023-12-06, 14:50:27.699234 [warning] - Number of eqdsk.rbdry/eqdsk.zbdry values read 89
-0000040 | 2023-12-06, 14:50:27.699255 [warning] - Reading eqdsk.rlim and eqdsk.zlim...
-0000041 | 2023-12-06, 14:50:27.699357 [warning] - Number of eqdsk.rlim/eqdsk.zlim values read 57
-0000042 | 2023-12-06, 14:50:27.699392 [trace] - -----equData.set_rsig()-----
-0000043 | 2023-12-06, 14:50:27.699404 [warning] - Value of rsig (psiqbdry-psiaxis) = -1
-0000044 | 2023-12-06, 14:50:27.699433 [info] - Override for ITER case applied. Sign of psi flipped
-0000045 | 2023-12-06, 14:50:27.699563 [warning] - DPSI =  0.160858
-0000046 | 2023-12-06, 14:50:27.699584 [warning] - PSIQBDRY = -2.51614
-0000047 | 2023-12-06, 14:50:27.699603 [warning] - PSIAXIS = -12.9719
-0000048 | 2023-12-06, 14:50:27.699624 [warning] - RSIG = -1
-0000049 | 2023-12-06, 14:50:27.699643 [warning] - RMIN = 3
-0000050 | 2023-12-06, 14:50:27.699664 [warning] - RMAX = 9
-0000051 | 2023-12-06, 14:50:27.699683 [warning] - ZMIN = -6
-0000052 | 2023-12-06, 14:50:27.699701 [warning] - ZMAX = 6
-0000053 | 2023-12-06, 14:50:27.699720 [warning] - dR = 0.09375
-0000054 | 2023-12-06, 14:50:27.699740 [warning] - dZ = 0.09375
-0000055 | 2023-12-06, 14:50:27.699761 [warning] - PSINORM = 5.22788
-0000056 | 2023-12-06, 14:50:27.699781 [warning] - IVAC = 33.7283
+0000001 | 2024-01-11, 11:28:15.156782 [trace] - -----equData.read_eqdsk()-----
+0000002 | 2024-01-11, 11:28:15.157250 [warning] - eqdsk file to be read - test.eqdsk
+0000003 | 2024-01-11, 11:28:15.157358 [warning] - Number of grid points in R (nw) = 65
+0000004 | 2024-01-11, 11:28:15.157379 [warning] - Number of grid points in Z (nh) = 129
+0000005 | 2024-01-11, 11:28:15.157422 [warning] - Geometry parameters from EFIT:
+0000006 | 2024-01-11, 11:28:15.157438 [warning] - Domain size in R eqdsk.rdim 6
+0000007 | 2024-01-11, 11:28:15.157474 [warning] - Domain size in Z eqdsk.zdim 12
+0000008 | 2024-01-11, 11:28:15.157491 [warning] - R at centre 6.2
+0000009 | 2024-01-11, 11:28:15.157507 [warning] - Domain start in R eqdsk.rgrid 3
+0000010 | 2024-01-11, 11:28:15.157523 [warning] - Domain centre in Z eqdsk.zmid 0
+0000011 | 2024-01-11, 11:28:15.157538 [warning] - Plasma parameters from EFIT:
+0000012 | 2024-01-11, 11:28:15.157552 [warning] - B at rcentre 5.3
+0000013 | 2024-01-11, 11:28:15.157568 [warning] - Flux at centre ssimag1 12.9719
+0000014 | 2024-01-11, 11:28:15.157586 [warning] - Flux at boundary ssibry1 2.51614
+0000015 | 2024-01-11, 11:28:15.157602 [warning] - Plasma centre in R eqdsk.rmaxis 6.37753
+0000016 | 2024-01-11, 11:28:15.157617 [warning] - Plasma centre in Z eqdsk.zmaxis -0.242403
+0000017 | 2024-01-11, 11:28:15.157633 [warning] - Plasma current 1.48039e+07
+0000018 | 2024-01-11, 11:28:15.157651 [trace] - -----equData.read_array()-----
+0000019 | 2024-01-11, 11:28:15.157664 [warning] - Reading eqdsk.fpol values...
+0000020 | 2024-01-11, 11:28:15.157706 [warning] - Number of eqdsk.fpol values read = 65
+0000021 | 2024-01-11, 11:28:15.157725 [trace] - -----equData.read_array()-----
+0000022 | 2024-01-11, 11:28:15.157733 [warning] - Reading eqdsk.pres values...
+0000023 | 2024-01-11, 11:28:15.157774 [warning] - Number of eqdsk.pres values read = 65
+0000024 | 2024-01-11, 11:28:15.157789 [trace] - -----equData.read_array()-----
+0000025 | 2024-01-11, 11:28:15.157798 [warning] - Reading eqdsk.ffprime values...
+0000026 | 2024-01-11, 11:28:15.157838 [warning] - Number of eqdsk.ffprime values read = 65
+0000027 | 2024-01-11, 11:28:15.157854 [trace] - -----equData.read_array()-----
+0000028 | 2024-01-11, 11:28:15.157863 [warning] - Reading eqdsk.pprime values...
+0000029 | 2024-01-11, 11:28:15.157902 [warning] - Number of eqdsk.pprime values read = 65
+0000030 | 2024-01-11, 11:28:15.157919 [trace] - -----equData.read_2darray()-----
+0000031 | 2024-01-11, 11:28:15.158002 [warning] - Reading Psi(R,Z) values...
+0000032 | 2024-01-11, 11:28:15.161051 [warning] - Number of Psi(R,Z) values read = 8385
+0000033 | 2024-01-11, 11:28:15.161081 [trace] - -----equData.read_array()-----
+0000034 | 2024-01-11, 11:28:15.161089 [warning] - Reading eqdsk.qpsi values...
+0000035 | 2024-01-11, 11:28:15.161125 [warning] - Number of eqdsk.qpsi values read = 65
+0000036 | 2024-01-11, 11:28:15.161139 [warning] - Number of boundary points 89
+0000037 | 2024-01-11, 11:28:15.161152 [warning] - Number of limiter points 57
+0000038 | 2024-01-11, 11:28:15.161171 [warning] - Reading eqdsk.rbdry and eqdsk.zbdry...
+0000039 | 2024-01-11, 11:28:15.161245 [warning] - Number of eqdsk.rbdry/eqdsk.zbdry values read 89
+0000040 | 2024-01-11, 11:28:15.161258 [warning] - Reading eqdsk.rlim and eqdsk.zlim...
+0000041 | 2024-01-11, 11:28:15.161314 [warning] - Number of eqdsk.rlim/eqdsk.zlim values read 57
+0000042 | 2024-01-11, 11:28:15.161327 [info] - Override for ITER case applied. Sign of psi flipped
+0000043 | 2024-01-11, 11:28:15.161422 [trace] - -----equData.set_rsig()-----
+0000044 | 2024-01-11, 11:28:15.161429 [warning] - Value of rsig (psiqbdry-psiaxis) = 1
+0000045 | 2024-01-11, 11:28:15.161444 [warning] - DPSI =  0.160858
+0000046 | 2024-01-11, 11:28:15.161458 [warning] - PSIQBDRY = -2.51614
+0000047 | 2024-01-11, 11:28:15.161472 [warning] - PSIAXIS = -12.9719
+0000048 | 2024-01-11, 11:28:15.161486 [warning] - RSIG = 1
+0000049 | 2024-01-11, 11:28:15.161500 [warning] - RMIN = 3
+0000050 | 2024-01-11, 11:28:15.161513 [warning] - RMAX = 9
+0000051 | 2024-01-11, 11:28:15.161527 [warning] - ZMIN = -6
+0000052 | 2024-01-11, 11:28:15.161541 [warning] - ZMAX = 6
+0000053 | 2024-01-11, 11:28:15.161554 [warning] - dR = 0.09375
+0000054 | 2024-01-11, 11:28:15.161568 [warning] - dZ = 0.09375
+0000055 | 2024-01-11, 11:28:15.161582 [warning] - PSINORM = 5.22788
+0000056 | 2024-01-11, 11:28:15.161596 [warning] - IVAC = 33.7283
+0000057 | 2024-01-11, 11:28:15.161612 [trace] - -----equData.init_interp_splines()-----
+0000058 | 2024-01-11, 11:28:15.169369 [trace] - -----equData.centre-----
+0000059 | 2024-01-11, 11:28:15.169398 [info] - (Rcen,Zcen) values taken from eqdsk (Rmaxis,Zmaxis)
+0000060 | 2024-01-11, 11:28:15.169406 [warning] - Rcen value calculated from equData.centre() = 6.37753
+0000061 | 2024-01-11, 11:28:15.169418 [warning] - Zcen value calculated from equData.centre() = -0.242403
+0000062 | 2024-01-11, 11:28:15.169429 [warning] - Psicen value calculated from equData.centre() = -12.9746


### PR DESCRIPTION
The big thing here is managing to achieve a pretty close level of agreement to the SMARDDA Test case Test-EQ3-inrshad1-inres1. This is probably the simplest SMARDDA test case both in terms of equilibrium processing (`geoq`) and particle tracking (`powcal`). Note that in order to get this working I did have to change the value of `rOutrBdry` from 8.1785 to 8.0785. 

Also notable is the fix for issue #3. Whilst finding a fix for this I inadvertently discovered I was incorrectly copying arrays of equilibrium data from the .eqdsk file resulting in a magnetic field that was slightly wrong. Full change details enclosed below. 

Additions/Changes
-
- Fixed the broken indexing for `fpol` array when creating the 1D poloidal flux spline
- Fixed sign issue when determining Cartesian B_y component that was resulting in flipped magnetic fields, compared to SMARDDA.
- Added variables `rmove`, `zmove` and `fscale` (all associated with moving/scaling the magnetic field data) to be stored within the `settings` class. Therefore allowing the user to specify these values in the config file.
- Moved around some `VTK` array insert statements to ensure that arrays have the correct values and number of elements when loop over triangles cycles prematurely (such as particle going out of bounds).
- Aegis main now just takes the absolute value of Q rather than flipping `B.n` to return a positive Q.
- Changed return type of `particleBase::check_if_in_bfield()` from `bool` to `void` so that the outOfBounds flag could just be a member variable of `particleBase` instead.
- Added a check to see if particle out of bounds when calling `particleBase::set_dir()` because it was leading to segfaults (divide by zero error when normalising magnetic field) when direction vector of a particle was attempted to be set when the particle is not in the magnetic field.
- Fixed missing logic from equilibrium data `ITER_OVERRIDE` flag that flipped the sign of `eqdsk.fpol` array in `equData::read_eqdsk()`. Also moved assignments that change based on sign of `psi` after the `ITER_OVERRIDE` sign flipping.

Actions/Changes required
-
Update `settings.cpp` to better manage variables and read them in. Current method of specifying variable type seems cumbersome. Ideally specify variables into groups for associated classes within the code
- Add `ITER_OVERRIDE` flag to settings/config file