### PR TITLE
Feature/mpi gather

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,12 @@ set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREAD ON)
 ADD_DEFINITIONS(-DBOOST_LOG_DYN_LINK)
 set(Boost_PACKAGES system log log_setup)
-set(BOOST_REQUESTED_VERSION 1.71)
+# set(BOOST_REQUESTED_VERSION 1.71)
 
 find_package(Boost REQUIRED COMPONENTS ${Boost_PACKAGES})
 find_package(OpenMP REQUIRED)
 find_package(MPI REQUIRED)
+# find_package(CGAL REQUIRED)
 add_subdirectory(externals/json)
 include_directories(externals/json/include)
 
@@ -60,13 +61,14 @@ vtk_module_autoinit(
 
 # Import DAGMC
 message(STATUS "Looking for DAGMC...")
-set(DAGMC_DIR="~/dagmc_bld/DAGMC/" CACHE PATH "Path to the DAGMC build or install prefix.")
+set(DAGMC_DIR="/home/waqar/dagmc_bld/DAGMC/" CACHE PATH "Path to the DAGMC build or install prefix.")
 
 if(DAGMC_DIR) 
    find_package(DAGMC REQUIRED NAMES DAGMC HINTS "${DAGMC_DIR}" 
 		"${DAGMC_DIR}/lib/cmake/dagmc" NO_DEFAULT PATH)
 else()
-find_package(DAGMC REQUIRED lib/cmake)
+list(APPEND CMAKE_PREFIX_PATH "/home/waqar/dagmc_bld/DAGMC")
+find_package(DAGMC REQUIRED)
 endif()
 message(STATUS "Found DAGMC config in: ${DAGMC_DIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,11 @@ include_directories(externals/json/include)
 
 # Default to cpmpile with debugging symbols
 set(CMAKE_BUILD_TYPE DEBUG)
-
+#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+#set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+# set(BUILD_TYPE "PROFILING")
+# set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pg")
+# set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -pg")
 #set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE})
 
 # Import VTK
@@ -104,8 +108,7 @@ elseif(BUILD_TYPE STREQUAL "RELEASE")
   message(STATUS "BUILD_TYPE SET TO RELEASE")
 
 elseif(BUILD_TYPE STREQUAL "PROFILING")
-  set(BUILD_TYPE_COMPILE_FLAGS "-g;-O0;")
-  set(TEST_LIBRARIES "")
+  set(BUILD_TYPE_COMPILE_FLAGS "-g;-O0;-pg")
   set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pg")
   set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -pg")
   message(STATUS "BUILD_TYPE SET TO PROFILING")

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -5,8 +5,9 @@
       "step_size": 0.005,
       "max_steps": 100000,
       "launch_pos": "fixed",
-      "target_surfs": [51],
-      "force_no_deposition": false
+      "target_surfs": [50,51,52,53,54,55],
+      "force_no_deposition": false,
+      "dynamic_task_size": 100
   },
   "equil_params":{
       "eqdsk": "EQ3.eqdsk",

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -23,6 +23,6 @@
   },
   "vtk_params":{
       "VTK": "target_facets.stl",
-      "draw_particle_tracks": true
+      "draw_particle_tracks": false
   }
  }

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -1,11 +1,11 @@
 {
   "description": "inres1 test case to compare against SMARDDA",
   "aegis_params":{
-      "DAGMC": "inres1_shad.h5m",
+      "DAGMC": "inres1_fine.h5m",
       "step_size": 0.005,
       "max_steps": 100000,
       "launch_pos": "fixed",
-      "target_surfs": [1,2,3,4,5,6],
+      "target_surfs": [51],
       "force_no_deposition": false
   },
   "equil_params":{

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -1,13 +1,13 @@
 {
   "description": "inres1 test case to compare against SMARDDA",
   "aegis_params":{
-      "DAGMC": "inres1_fine.h5m",
+      "DAGMC": "inres1_shad.h5m",
       "step_size": 0.005,
       "max_steps": 100000,
       "launch_pos": "fixed",
-      "target_surfs": [50,51,52,53,54,55],
+      "target_surfs": [1,2,3,4,5,6],
       "force_no_deposition": false,
-      "dynamic_task_size": 100
+      "dynamic_task_size": 200
   },
   "equil_params":{
       "eqdsk": "EQ3.eqdsk",
@@ -23,6 +23,6 @@
   },
   "vtk_params":{
       "VTK": "target_facets.stl",
-      "draw_particle_tracks": false
+      "draw_particle_tracks": true
   }
  }

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
   }
   else
   {
-    simulation.Execute_mpi();
+    simulation.Execute_split();
   }
 
 

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -10,6 +10,12 @@ int main(int argc, char **argv) {
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
 
+  // if (nprocs < 2)
+  // {
+  //     std::cout << "Error! This program requires at least two processes to run. Exiting... \n";
+  //     std::exit(1);
+  // }
+
   std::string settingsFile;
   if (argc > 1) 
   {

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -10,11 +10,11 @@ int main(int argc, char **argv) {
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
 
-  // if (nprocs < 2)
-  // {
-  //     std::cout << "Error! This program requires at least two processes to run. Exiting... \n";
-  //     std::exit(1);
-  // }
+  if (nprocs < 2)
+  {
+      std::cout << "Error! This program requires at least two processes to run. Exiting... \n";
+      std::exit(1);
+  }
 
   std::string settingsFile;
   if (argc > 1) 

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -10,12 +10,6 @@ int main(int argc, char **argv) {
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
 
-  if (nprocs < 2)
-  {
-      std::cout << "Error! This program requires at least two processes to run. Exiting... \n";
-      std::exit(1);
-  }
-
   std::string settingsFile;
   if (argc > 1) 
   {
@@ -23,12 +17,22 @@ int main(int argc, char **argv) {
   }
   else 
   {
-    std::cout << "Error - No config file provided, defaulting to 'aegis_settings.json'" << std::endl;
+    if (rank == 0) {std::cout << "Error - No config file provided, defaulting to 'aegis_settings.json'" << std::endl;}
     settingsFile = "aegis_settings.json";
   }
- 
+
   ParticleSimulation simulation(settingsFile);
-  simulation.Execute();
+  
+  if (nprocs < 2)
+  {
+    std::cout << "Running on a single core in serial mode... \n";
+    simulation.Execute();
+  }
+  else
+  {
+    simulation.Execute_mpi();
+  }
+
 
   for (int i=0; i<nprocs; ++i){
     if (rank == i)

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -27,10 +27,12 @@ int main(int argc, char **argv) {
   {
     std::cout << "Running on a single core in serial mode... \n";
     simulation.Execute();
+    // simulation.Execute_padded_mpi();
   }
   else
-  {
-    simulation.Execute_split();
+  { 
+    simulation.Execute_mpi();
+    //simulation.Execute_padded_mpi();
   }
 
 

--- a/src/aegis_lib/AegisBase.cpp
+++ b/src/aegis_lib/AegisBase.cpp
@@ -1,0 +1,87 @@
+#include "AegisBase.h"
+#include <mpi.h>
+
+
+
+
+// print error message and MPI_Finalize() exit out of code
+void AegisBase::error_exit_mpi(std::string inString, std::string file, std::string func, int line, int rank)
+{
+  std::cout << file << ":" << func << ":" << line << ":RANK[" << rank << "] --- " 
+            << inString << std::endl;
+  if (MPI_Finalize() != MPI_SUCCESS) {
+    std::cout << "ERROR: MPI_Finalize != MPI_SUCCESS" << std::endl;
+  }
+  std::exit(1);
+}
+
+// cout for strings only on rank 0
+void AegisBase::print_mpi(std::string inString)
+{
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  if (rank == 0)
+  {
+    std::cout << inString << std::endl;
+  }
+}
+
+// wrapper for boost LOG macros to test for MPI rank
+void AegisBase::log_string(LogLevel level, std::string inString)
+{
+
+  if (rank == 0)
+  {
+    switch (level)
+    {
+      case LogLevel::INFO:
+        LOG_INFO << inString; 
+        break;
+
+      case LogLevel::TRACE:
+        LOG_TRACE << inString; 
+        break;
+
+      case LogLevel::WARNING:
+        LOG_WARNING << inString; 
+        break;
+
+      case LogLevel::ERROR:
+        LOG_ERROR << inString; 
+        break;
+
+      case LogLevel::FATAL:
+        LOG_FATAL << inString; 
+        break;
+
+      default:
+        LOG_WARNING << inString;
+    }
+  }
+
+}
+
+// return MPI rank
+int AegisBase::get_mpi_rank()
+{
+  return rank; 
+}
+
+// return MPI size in MPI_COMM_WORLD
+int AegisBase::get_mpi_size()
+{
+  return nprocs;
+}
+
+// call MPI_Comm_rank and MPI_Comm_size 
+void AegisBase::set_mpi_params()
+{
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+}
+
+
+void AegisBase::setup_logger()
+{
+
+}

--- a/src/aegis_lib/AegisBase.cpp
+++ b/src/aegis_lib/AegisBase.cpp
@@ -26,6 +26,18 @@ void AegisBase::print_mpi(std::string inString)
   }
 }
 
+void AegisBase::setup_profiling()
+{
+  profiling.open("aegis_profiling.txt");
+  profiling << "Object to time | " << " elapsed wall time | " << "Rank of process" << std::endl;
+  log_string(LogLevel::WARNING, "saving aegis profiling data to aegis_profiling.txt");
+}
+
+void AegisBase::out_mpi_wtime(std::string inString, double totalTime)
+{
+  profiling << inString << " | " << totalTime << "s | " << rank << std::endl;
+}
+
 // wrapper for boost LOG macros to test for MPI rank
 void AegisBase::log_string(LogLevel level, std::string inString)
 {

--- a/src/aegis_lib/AegisBase.h
+++ b/src/aegis_lib/AegisBase.h
@@ -1,0 +1,49 @@
+#ifndef AegisBase__
+#define AegisBase__
+
+#include <iostream>
+#include <string>
+#include <SimpleLogger.h>
+#include <boost/log/trivial.hpp>
+#include <boost/log/sources/global_logger_storage.hpp>
+
+enum class LogLevel
+{
+  INFO, 
+  TRACE,
+  WARNING,
+  ERROR,
+  FATAL
+};
+
+namespace logging = boost::log;
+namespace src = boost::log::sources;
+namespace expr = boost::log::expressions;
+namespace sinks = boost::log::sinks;
+namespace attrs = boost::log::attributes;
+
+// Base class for all AEGIS objects with some utility functions (mostly around MPI)
+class AegisBase 
+{
+  public:
+
+  protected:
+  void setup_logger();
+  void error_exit_mpi(std::string inString, std::string file, std::string func, int line, int rank);
+  void print_mpi(std::string inString);
+  void log_string(LogLevel level, std::string inString);
+  void set_mpi_params();
+  int get_mpi_rank();
+  int get_mpi_size();
+  
+  src::severity_logger_mt<boost::log::trivial::severity_level> logger;
+
+  int rank; 
+  int nprocs;
+
+  private:
+
+
+};
+
+#endif

--- a/src/aegis_lib/AegisBase.h
+++ b/src/aegis_lib/AegisBase.h
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <string>
+#include <fstream>
 #include <SimpleLogger.h>
 #include <boost/log/trivial.hpp>
 #include <boost/log/sources/global_logger_storage.hpp>
@@ -32,6 +33,8 @@ class AegisBase
   void error_exit_mpi(std::string inString, std::string file, std::string func, int line, int rank);
   void print_mpi(std::string inString);
   void log_string(LogLevel level, std::string inString);
+  void setup_profiling();
+  void out_mpi_wtime(std::string inString, double totalTime);
   void set_mpi_params();
   int get_mpi_rank();
   int get_mpi_size();
@@ -40,6 +43,7 @@ class AegisBase
 
   int rank; 
   int nprocs;
+  std::ofstream profiling;
 
   private:
 

--- a/src/aegis_lib/EquilData.h
+++ b/src/aegis_lib/EquilData.h
@@ -8,6 +8,7 @@
 #include "alglib/interpolation.h"
 #include "Inputs.h"
 #include "SimpleLogger.h"
+#include "AegisBase.h"
 
 
 struct eqdskData
@@ -47,7 +48,8 @@ struct eqdskData
 };
 
 
-class EquilData{
+class EquilData : public AegisBase
+{
 
   eqdskData eqdsk;  
   std::string className = "EquilData";
@@ -195,6 +197,8 @@ class EquilData{
   alglib::spline1dinterpolant fSpline; // 1d spline interpolant for f(psi) or I(psi) toroidal component
 
   private:
+  int rank, nprocs;
+
   bool debug = false;
   bool drawEquRZ = false;
   bool drawEquXYZ = false;

--- a/src/aegis_lib/Inputs.cpp
+++ b/src/aegis_lib/Inputs.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <sstream>
 #include "Inputs.h"
+#include <mpi.h>
 
 
 
@@ -21,16 +22,18 @@ InputJSON::InputJSON(std::string filename){
 }
 
 json InputJSON::read_json(){
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   std::ifstream file(filepath);
   if (file.is_open())
   {
-    std::cout << "Settings found in JSON file '" << filepath << "'" << std::endl;
+    if (rank == 0) {std::cout << "Settings found in JSON file '" << filepath << "'" << std::endl;}
     json data = json::parse(file); 
     return data;
   }
   else
   {
-    std::cout << "Error! The requested JSON file '" << filepath << "' does not exist." << std::endl;  
-    exit(EXIT_FAILURE);
+    if (rank == 0) {std::cout << "Error! The requested JSON file '" << filepath << "' does not exist." << std::endl;}  
+    std::exit(EXIT_FAILURE);
   }
 } 

--- a/src/aegis_lib/Inputs.h
+++ b/src/aegis_lib/Inputs.h
@@ -18,7 +18,8 @@
 
 using json = nlohmann::json;
 
-class InputJSON{
+class InputJSON
+{
   public:
   InputJSON();
   InputJSON(std::string filename);

--- a/src/aegis_lib/Integrator.cpp
+++ b/src/aegis_lib/Integrator.cpp
@@ -13,7 +13,6 @@
 // initialise list of EntityHandles and maps associated with 
 SurfaceIntegrator::SurfaceIntegrator(moab::Range const &Facets)
 {
-  LOG_TRACE << "-----SurfaceIntegrator CONSTRUCTOR()-----";
 
   nFacets = Facets.size();
 
@@ -29,7 +28,6 @@ SurfaceIntegrator::SurfaceIntegrator(moab::Range const &Facets)
 // Overload for constructor use with STL vector
 SurfaceIntegrator::SurfaceIntegrator(std::vector<EntityHandle> const &Facets)
 {
-  LOG_TRACE << "-----SurfaceIntegrator CONSTRUCTOR()-----";
 
   nFacets = Facets.size();
 
@@ -117,6 +115,8 @@ void SurfaceIntegrator::ray_reflect_dir(double const prev_dir[3], double const s
 // return sorted map of EntityHandles against ints 
 void SurfaceIntegrator::facet_values(std::unordered_map<moab::EntityHandle, int> const &map)
 {
+  if (rank == 0)
+  {
     int_sorted_map sortedMap(map.begin(), map.end());
     for (auto const &pair: sortedMap)
     {
@@ -125,11 +125,13 @@ void SurfaceIntegrator::facet_values(std::unordered_map<moab::EntityHandle, int>
         std::cout << "EntityHandle: " << pair.first << "[" << pair.second << "] rays hit" << std::endl;
       }
     }
+  }
 }
 
 // return sorted map of EntityHandles against doubles 
 void SurfaceIntegrator::facet_values(std::unordered_map<moab::EntityHandle, double> const &map)
-{
+{ if (rank == 0)
+  {
     std::cout << std::endl;
     std::cout << "Heat flux deposited per facet" << std::endl;
     std::cout << std::endl;
@@ -142,6 +144,7 @@ void SurfaceIntegrator::facet_values(std::unordered_map<moab::EntityHandle, doub
         std::cout << "EntityHandle:" << pair.first << " [" << pair.second << "] MW/m^2" << std::endl;
       }
     }
+  }
 }
 
 // output values of unordered_map to csv format
@@ -219,12 +222,14 @@ void SurfaceIntegrator::piecewise_multilinear_out(std::unordered_map<moab::Entit
 
 void SurfaceIntegrator::print_particle_stats(){ // return number of particles depositing, shadowed, lost etc.
 
-  LOG_WARNING << "Number of particles launched = " << nFacets;
-  LOG_WARNING << "Number of particles depositing power from omp = " << nParticlesHeatDep;
-  LOG_WARNING << "Number of shadowed particle intersections = " << nParticlesShadowed;
-  LOG_WARNING << "Number of particles lost from magnetic domain = " << nParticlesLost;
-  LOG_WARNING << "Number of particles terminated upon reaching max tracking length = " << nParticlesMaxLength; 
-
+  if (rank == 0)
+  {
+    LOG_WARNING << "Number of particles launched = " << nFacets;
+    LOG_WARNING << "Number of particles depositing power from omp = " << nParticlesHeatDep;
+    LOG_WARNING << "Number of shadowed particle intersections = " << nParticlesShadowed;
+    LOG_WARNING << "Number of particles lost from magnetic domain = " << nParticlesLost;
+    LOG_WARNING << "Number of particles terminated upon reaching max tracking length = " << nParticlesMaxLength; 
+  }
 };
 
 void SurfaceIntegrator::set_launch_position(const moab::EntityHandle &facet, const std::vector<double> &position){

--- a/src/aegis_lib/Integrator.h
+++ b/src/aegis_lib/Integrator.h
@@ -13,6 +13,7 @@
 #include "moab/Interface.hpp"
 #include <moab/OrientedBoxTreeTool.hpp>
 #include "EquilData.h"
+#include "AegisBase.h"
 
 
 
@@ -47,7 +48,7 @@ MAXLENGTH // max length reached
 
 // integrator .h file
 
-class SurfaceIntegrator 
+class SurfaceIntegrator : public AegisBase
 {
   public:
   SurfaceIntegrator(moab::Range const &Facets); // constructor (with moab::Range)

--- a/src/aegis_lib/Integrator.h
+++ b/src/aegis_lib/Integrator.h
@@ -42,7 +42,8 @@ enum class terminationState{
 DEPOSITING, // midplane reached 
 SHADOWED, // shadow geometry hit
 LOST, // left magnetic domain
-MAXLENGTH // max length reached
+MAXLENGTH, // max length reached
+PADDED // padded null particle
 };
 
 
@@ -56,7 +57,7 @@ class SurfaceIntegrator : public AegisBase
   void count_hit(EntityHandle facet_hit); // count hits belonging to each facet
   void count_lost_ray();
   void store_heat_flux(EntityHandle facet, double heatflux); // store the power associated with a particular facet
-  void count_particle(EntityHandle facet, terminationState termination, double heatflux);
+  void count_particle(const EntityHandle &facet, terminationState termination,const double &heatflux);
 
   void ray_reflect_dir(double const prev_dir[3], double const surface_normal[3], // get reflected dir
                          double reflected_dir[3]); 
@@ -71,14 +72,15 @@ class SurfaceIntegrator : public AegisBase
   void print_particle_stats(); // return number of particles depositing, shadowed, lost, etc...
 
   void set_launch_position(const moab::EntityHandle &facet, const std::vector<double> &position);
-  std::array<int, 4> particle_stats(); // return array of integers corresponding to particle stats
-
+  std::array<int, 5> particle_stats(); // return array of integers corresponding to particle stats
+  void clear_stats();
   private:
   int nParticlesTotal=0; // Total number of rays fired into geometry
   int nParticlesShadowed=0; // Number of particles shadowed
   int nParticlesLost=0; // number of particles lost from magnetic domain
   int nParticlesHeatDep=0; // number of particles despositing heat
   int nParticlesMaxLength=0; // number of particles reached max termination length
+  int nParticlesPadded=0; // number of padded null particles 
 
   int nFacets=0; // Number of facets in geometry
   std::vector<EntityHandle> facetEntities; // list of all entity handles in geometry

--- a/src/aegis_lib/Particle.cpp
+++ b/src/aegis_lib/Particle.cpp
@@ -124,6 +124,13 @@ void ParticleBase::update_vectors(double distanceTravelled)
   // This will update the position 
   std::vector<double> newPt(3);
 
+  double x2= pow((newPt[0]-pos[0]), 2);
+  double y2= pow((newPt[1]-pos[1]), 2);
+  double z2= pow((newPt[2]-pos[2]), 2);
+  double thresholdDistUpdate = sqrt(x2 + y2 + z2);
+
+  euclidDistTravelled += thresholdDistUpdate;
+
   newPt[0] = pos[0] + dir[0] * distanceTravelled;
   newPt[1] = pos[1] + dir[1] * distanceTravelled;
   newPt[2] = pos[2] + dir[2] * distanceTravelled;
@@ -176,4 +183,27 @@ void ParticleBase::check_if_midplane_reached(const std::array<double, 3> &midpla
       else if (r >= rOuterMidplane) {atMidplane = 2;}
     }
   }
+}
+
+// set distance threshold where if particle has travlled less, ray_fire() calls do not happen
+void ParticleBase::set_intersection_threshold(double distanceThreshold)
+{
+  thresholdDistanceThreshold = distanceThreshold;
+  thresholdDistanceCrossed = false;
+  thresholdDistanceSet = true;
+}
+
+// check if the distance threshold for ray_fire() calls has been called
+// if true returned ray_fire() should be called
+// if false returned then particle position should update without ray_fire()
+bool ParticleBase::check_if_threshold_crossed()
+{
+  if (euclidDistTravelled > thresholdDistanceThreshold)
+    {
+      thresholdDistanceThreshold = 0.0;
+      euclidDistTravelled = 0.0;
+      thresholdDistanceSet = false;
+      return true;
+    }
+  return false;
 }

--- a/src/aegis_lib/Particle.cpp
+++ b/src/aegis_lib/Particle.cpp
@@ -9,8 +9,8 @@
 #include <moab/OrientedBoxTreeTool.hpp>
 #include "SimpleLogger.h"
 
-
-void ParticleBase::set_pos(std::vector<double> newPosition) // set current particle position
+// set current particle position
+void ParticleBase::set_pos(std::vector<double> newPosition) 
 {
   if (pos.empty()) 
   { 
@@ -22,7 +22,8 @@ void ParticleBase::set_pos(std::vector<double> newPosition) // set current parti
   pos = newPosition; // set the new position
 }
 
-void ParticleBase::set_pos(double newPosition[]) // overload set_pos() for C-style array
+// overload set_pos() for C-style array
+void ParticleBase::set_pos(double newPosition[]) 
 {
   std::vector<double> tempVector(3);
   for (int i=0; i<3; i++)
@@ -37,6 +38,7 @@ void ParticleBase::set_pos(double newPosition[]) // overload set_pos() for C-sty
   pos = tempVector; // set the new position  
 }
 
+// Check if particle is currently in magnetic field
 void ParticleBase::check_if_in_bfield(EquilData &equilibrium)
 {
   std::vector<double> currentBfield = equilibrium.b_field(pos, "cart");
@@ -44,7 +46,8 @@ void ParticleBase::check_if_in_bfield(EquilData &equilibrium)
   else {outOfBounds = false;}
 }
 
-std::vector<double> ParticleBase::get_pos(std::string coordType) // return STL vector of current particle position
+// return STL vector of current particle position
+std::vector<double> ParticleBase::get_pos(std::string coordType) 
 {
   // make coordType lowercase
   std::transform(coordType.begin(), coordType.end(), coordType.begin(), 
@@ -62,7 +65,8 @@ std::vector<double> ParticleBase::get_pos(std::string coordType) // return STL v
   }
 }
 
-double ParticleBase::get_psi(EquilData &equilibrium) // return double of psi at current pos
+// return double of psi at current pos
+double ParticleBase::get_psi(EquilData &equilibrium) 
 {
   std::vector<double> currentPosition;
   double psi;
@@ -73,7 +77,8 @@ double ParticleBase::get_psi(EquilData &equilibrium) // return double of psi at 
   return psi;
 }
 
-void ParticleBase::set_dir(EquilData &equilibrium) // Set unit direction vector along cartesian magnetic field vector
+// set unit drection vector and Bfield at current position
+void ParticleBase::set_dir(EquilData &equilibrium) 
 {
   check_if_in_bfield(equilibrium);
   if (outOfBounds) {return;} // exit function early if out of bounds
@@ -94,12 +99,14 @@ void ParticleBase::set_dir(EquilData &equilibrium) // Set unit direction vector 
   dir = normB;
 }
 
+// get current particle direction (along magnetic field)
 std::vector<double> ParticleBase::get_dir(std::string coordType)
 {
   std::vector<double> currentDirection = dir;
   return currentDirection;
 }
 
+// align particle direction along surface normal of facet particle launched from
 void ParticleBase::align_dir_to_surf(double Bn)
 {
 
@@ -111,6 +118,7 @@ void ParticleBase::align_dir_to_surf(double Bn)
   }
 }
 
+// update position vector of particle with set distance travelled
 void ParticleBase::update_vectors(double distanceTravelled)
 {
   // This will update the position 
@@ -123,6 +131,7 @@ void ParticleBase::update_vectors(double distanceTravelled)
   set_pos(newPt);
 }
 
+// update position vector of particle with set distance travelled and update the particle direction at new position
 void ParticleBase::update_vectors(double distanceTravelled, EquilData &equilibrium)
 {
   // This will update the position and direction vector of the particle 
@@ -136,6 +145,7 @@ void ParticleBase::update_vectors(double distanceTravelled, EquilData &equilibri
   set_dir(equilibrium);
 }
 
+// check if the particle has reached the outer-midplane of plasma (TerminationState = DEPOSITING)
 void ParticleBase::check_if_midplane_reached(const std::array<double, 3> &midplaneParameters)
 {
   double x = pos[0];

--- a/src/aegis_lib/Particle.h
+++ b/src/aegis_lib/Particle.h
@@ -26,6 +26,9 @@ class ParticleBase : public AegisBase
   double lengthTravelled = 0.0; // total length travelled by particle
   bool directionUp = false; 
   std::vector<double> previousPos;
+  double thresholdDistanceThreshold = 0.0;
+  double euclidDistTravelled = 0.0;
+  bool thresholdDistanceCrossed = false;
   //DagMC::RayHistory history; // stores entity handles of surfaces crossed and facets hit
 
   public:
@@ -36,6 +39,7 @@ class ParticleBase : public AegisBase
   std::vector<double> launchPos; // initial starting position of particle on triangle
   int atMidplane; // 0 == Not at midplane; 1 == At Inner-Midplane; 2 == At Outer-Midplane  
   bool outOfBounds = false;
+  bool thresholdDistanceSet = false;
 
   void set_pos(std::vector<double> newPosition); // set new particle position
   void set_pos(double newPosition[]); // overload for C-style array
@@ -48,6 +52,8 @@ class ParticleBase : public AegisBase
   void update_vectors(double distanceTravelled); // update position  
   void update_vectors(double distanceTravelled, EquilData &EquData); // overload to update dir as well
   void check_if_midplane_reached(const std::array<double, 3> &midplaneParameters); // check if particle has reached inner or outer midplane and set value of atMidplane
+  void set_intersection_threshold(double distanceThreshold);
+  bool check_if_threshold_crossed();
 
 };
 

--- a/src/aegis_lib/Particle.h
+++ b/src/aegis_lib/Particle.h
@@ -19,7 +19,7 @@
 
 
 
-class ParticleBase 
+class ParticleBase : public AegisBase
 {
   private:
   double power = 0.0; // power associated with particle

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -64,6 +64,7 @@ class ParticleSimulation : public AegisBase
   ParticleSimulation(std::string filename);
   void Execute();
   void Execute_mpi(); 
+  void Execute_split();
   void init_geometry();
   int num_facets();
   std::vector<std::pair<double,double>> psiQ_values; // for l2 norm test
@@ -73,6 +74,7 @@ class ParticleSimulation : public AegisBase
 
   private:
   void dynamic_task_init();
+  void implicit_complement_testing(); 
   moab::Range select_target_surface(); // get target surfaces of interest from aegis_settings.json
   std::vector<double> loop_over_facets(int startFacet, int endFacet,const  moab::Range targetSurfaceList); // loop over facets in target surfaces
   terminationState loop_over_particle_track(const moab::EntityHandle &facet, ParticleBase &particle, DagMC::RayHistory &history); // loop over individual particle tracks
@@ -102,8 +104,9 @@ class ParticleSimulation : public AegisBase
   double psiref = 0.0;
   bool noMidplaneTermination = false;
   std::vector<int> vectorOfTargetSurfs;
-
-  std::stringstream stringToPrint;
+  unsigned int numberOfRayFireCalls = 0;
+  unsigned int numberOfClosestLocCalls = 0;
+  unsigned int counter=0;
 
   std::unique_ptr<moab::DagMC> DAG;
   std::unique_ptr<moab::DagMC> polarDAG;
@@ -114,12 +117,13 @@ class ParticleSimulation : public AegisBase
   int numNodes = 0;
   moab::EntityHandle prevSurf;
   moab::EntityHandle nextSurf;
-  moab::EntityHandle volID; 
+  moab::EntityHandle implComplementVol; 
   double nextSurfDist = 0.0; // distance to next surface
   moab::EntityHandle intersectedFacet;
   int rayOrientation = 1; // rays are fired along surface normals
   double trackLength = 0.0;
   int facetCounter = 0;
+
   std::vector<double> qValues;
   std::vector<double> psiValues;
 

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -58,13 +58,22 @@
 
 using namespace moab;
 
+
+enum class meshWriteOptions{
+FULL, // write out all mesh sets
+TARGET, // write out only the target mesh set
+BOTH, // write out target and full mesh to seperate files
+PARTIAL // write out multiple specified mesh sets to a single file
+};
+
 class ParticleSimulation : public AegisBase
 {
   public:
   ParticleSimulation(std::string filename);
-  void Execute();
-  void Execute_mpi(); 
-  void Execute_split();
+  void Execute(); // serial
+  void Execute_mpi(); // MPI_Gatherv
+  void Execute_dynamic_mpi(); // dynamic load balancing
+  void Execute_padded_mpi(); // padded MPI_Gather
   void init_geometry();
   int num_facets();
   std::vector<std::pair<double,double>> psiQ_values; // for l2 norm test
@@ -76,13 +85,17 @@ class ParticleSimulation : public AegisBase
   void dynamic_task_init();
   void implicit_complement_testing(); 
   moab::Range select_target_surface(); // get target surfaces of interest from aegis_settings.json
-  std::vector<double> loop_over_facets(int startFacet, int endFacet,const  moab::Range targetSurfaceList); // loop over facets in target surfaces
+  std::vector<double> loop_over_facets(int startFacet, int endFacet); // loop over facets in target surfaces
   terminationState loop_over_particle_track(const moab::EntityHandle &facet, ParticleBase &particle, DagMC::RayHistory &history); // loop over individual particle tracks
   void terminate_particle(const moab::EntityHandle &facet, DagMC::RayHistory &history, terminationState termination); // end particle track
   void ray_hit_on_launch(ParticleBase &particle, DagMC::RayHistory &history); // particle hit on initial launch from surface
-  void print_particle_stats(std::array<int, 4> particleStats); // print number of particles that reached each termination state
+  void print_particle_stats(std::array<int, 5> particleStats); // print number of particles that reached each termination state
   void mpi_particle_stats(); // get inidividual particle stats for each process
   void read_params(const std::shared_ptr<InputJSON> &inputs); // read parameters from aegis_settings.json
+  void attach_mesh_attribute(const std::string &tagName, moab::Range &entities, std::vector<double> &dataToAttach);
+  void write_out_mesh(meshWriteOptions option, moab::Range rangeOfEntities = {});
+
+  
   int nFacets;
   
   std::string settingsFileName;
@@ -106,13 +119,14 @@ class ParticleSimulation : public AegisBase
   std::vector<int> vectorOfTargetSurfs;
   unsigned int numberOfRayFireCalls = 0;
   unsigned int numberOfClosestLocCalls = 0;
-  unsigned int counter=0;
+  unsigned int iterationCounter=0;
 
   std::unique_ptr<moab::DagMC> DAG;
   std::unique_ptr<moab::DagMC> polarDAG;
   moab::Range surfsList;
   moab::Range volsList;
   moab::Range facetsList;
+  moab::Range targetFacets;
   int numFacets = 0;
   int numNodes = 0;
   moab::EntityHandle prevSurf;
@@ -126,6 +140,9 @@ class ParticleSimulation : public AegisBase
 
   std::vector<double> qValues;
   std::vector<double> psiValues;
+  double startTime;
+  double endTime;
+  double facetsLoopTime;
 
   EquilData equilibrium;
   bool plotBFieldRZ = false;

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -73,7 +73,7 @@ class ParticleSimulation
   private:
   void dynamic_task_init();
   moab::Range select_target_surface();
-  void loop_over_facets(int startFacet, int endFacet,const  moab::Range targetSurfaceList);
+  std::vector<double> loop_over_facets(int startFacet, int endFacet,const  moab::Range targetSurfaceList);
   bool loop_over_particle_track(const moab::EntityHandle &facet, ParticleBase &particle, DagMC::RayHistory &history);
   void terminate_particle(const moab::EntityHandle &facet, DagMC::RayHistory &history, terminationState termination);
   void ray_hit_on_launch(ParticleBase &particle, DagMC::RayHistory &history);

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -71,8 +71,10 @@ class ParticleSimulation
   protected:
 
   private:
+  void dynamic_task_init();
   moab::Range select_target_surface();
-  void loop_over_particle_track(const moab::EntityHandle &facet, ParticleBase &particle, DagMC::RayHistory &history);
+  void loop_over_facets(int startFacet, int endFacet,const  moab::Range targetSurfaceList);
+  bool loop_over_particle_track(const moab::EntityHandle &facet, ParticleBase &particle, DagMC::RayHistory &history);
   void terminate_particle(const moab::EntityHandle &facet, DagMC::RayHistory &history, terminationState termination);
   void ray_hit_on_launch(ParticleBase &particle, DagMC::RayHistory &history);
   void print_particle_stats(std::array<int, 4> particleStats);

--- a/src/aegis_lib/SimpleLogger.cpp
+++ b/src/aegis_lib/SimpleLogger.cpp
@@ -48,9 +48,9 @@ BOOST_LOG_GLOBAL_LOGGER_INIT(logger, src::severity_logger_mt) {
     // specify the format of the log message
     logging::formatter formatter = expr::stream
         << std::setw(7) << std::setfill('0') << line_id << std::setfill(' ') << " | "
-        << expr::format_date_time(timestamp, "%Y-%m-%d, %H:%M:%S.%f") << " "
+        << expr::format_date_time(timestamp, "%H:%M:%S.%f") << " "
         << "[" << logging::trivial::severity << "]"
-        << " - " << expr::smessage;
+        << "|" << expr::smessage;
     consoleSink->set_formatter(formatter);
     fileSink->set_formatter(formatter);
 

--- a/src/aegis_lib/Source.h
+++ b/src/aegis_lib/Source.h
@@ -17,7 +17,8 @@ using moab::DagMC;
 using moab::OrientedBoxTreeTool;
 
 
-class pointSource{
+class pointSource
+{
   public:
   double r[3];
   double dir[3];
@@ -29,14 +30,16 @@ class pointSource{
 };
 
 
-class sphereSource{
+class sphereSource
+{ 
   public:
   double sample[3]; //sampled position
   double origin[3]; // origin of sphere
   double r; // radius of sphere
 };
 
-class boxSource{
+class boxSource
+{
   public:
   double pA[3];
   double pB[3];
@@ -48,9 +51,8 @@ class boxSource{
 
 };
 
-class TriSource
+class TriSource : public AegisBase
 {
-
   private:
   std::vector<double> xyzA;
   std::vector<double> xyzB;
@@ -67,8 +69,6 @@ class TriSource
   std::vector<double> random_pt();
   std::vector<double> centroid();
   double dot_product(std::vector<double> externalVector);
-
-
 
 };
 

--- a/src/aegis_lib/VtkInterface.cpp
+++ b/src/aegis_lib/VtkInterface.cpp
@@ -47,14 +47,6 @@ void VtkInterface::init(){
     init_Ptrack_root();
   }
 
-  new_vtkArray("Q", 1);
-  // new_vtkArray("B.n_direction", 1);
-  // new_vtkArray("Normal", 3);
-  // new_vtkArray("B_field", 3);
-  // new_vtkArray("Psi_Start", 1);
-  // new_vtkArray("B.n", 1);
-
-  
   if (drawParticleTracks && rank == 0){
     std::cout << "vtkMultiBlockDataSet initialised for particle tracks" << std::endl; 
   }
@@ -137,8 +129,8 @@ void VtkInterface::write_unstructuredGrid(std::string fileName)
 
 void VtkInterface::write_particle_track(std::string branchName, double heatflux){
   
-  if (!drawParticleTracks) {return;} // early return if drawing particle tracks disabled
-  else{
+  if (drawParticleTracks && rank == 0) 
+  { 
     init_Ptrack_branch(branchName);
     vtkNew<vtkPolyData> polydataTrack;
     polydataTrack = new_track(branchName, particleTrackPoints, heatflux);

--- a/src/aegis_lib/VtkInterface.cpp
+++ b/src/aegis_lib/VtkInterface.cpp
@@ -129,7 +129,7 @@ void VtkInterface::write_unstructuredGrid(std::string fileName)
 
 void VtkInterface::write_particle_track(std::string branchName, double heatflux){
   
-  if (drawParticleTracks && rank == 0) 
+  if (drawParticleTracks) 
   { 
     init_Ptrack_branch(branchName);
     vtkNew<vtkPolyData> polydataTrack;

--- a/src/aegis_lib/VtkInterface.cpp
+++ b/src/aegis_lib/VtkInterface.cpp
@@ -55,7 +55,7 @@ void VtkInterface::init(){
   // new_vtkArray("B.n", 1);
 
   
-  if (drawParticleTracks){
+  if (drawParticleTracks && rank == 0){
     std::cout << "vtkMultiBlockDataSet initialised for particle tracks" << std::endl; 
   }
 }
@@ -97,7 +97,9 @@ void VtkInterface::new_vtkArray(std::string arrName, int nComponents)
   tempArray->SetNumberOfComponents(nComponents);
   tempArray->SetName(arrName.data());
   arrays.insert(std::make_pair(arrName.data(), tempArray));
-  LOG_INFO << "Initialised new vtkDoubleArray '" << arrName  << "' with nComponents = " << nComponents;
+  std::stringstream newVtkArrayOut;
+  newVtkArrayOut << "Initialised new vtkDoubleArray '" << arrName  << "' with nComponents = " << nComponents;
+  log_string(LogLevel::INFO, newVtkArrayOut.str());
 }
 
 void VtkInterface::add_vtkArrays() // read stl and add arrays
@@ -107,7 +109,7 @@ void VtkInterface::add_vtkArrays() // read stl and add arrays
   vtkstlReader->SetFileName(vtk_input_file.data());
   vtkstlReader->Update();
   
-  LOG_INFO << "Initialising vtkUnstructuredGrid... ";
+  log_string(LogLevel::INFO,"Initialising vtkUnstructuredGrid...");
 
 
   // Transform PolyData to vtkUnstructuredGrid datatype using append filter
@@ -120,7 +122,6 @@ void VtkInterface::add_vtkArrays() // read stl and add arrays
   for (const auto &arr: arrays)
   {
     unstructuredGrid->GetCellData()->AddArray(arr.second);
-    //LOG_INFO << "Added array '" << arr.second << "' to vtkUnstructuredGrid";
   }
 }
 
@@ -166,7 +167,6 @@ void VtkInterface::insert_next_uStrGrid(std::string arrayName, std::vector<doubl
 
 void VtkInterface::insert_next_uStrGrid(std::string arrayName, double valueToAdd){
   arrays[arrayName]->InsertNextTuple1(valueToAdd);
-  std::cout << valueToAdd << std::endl;
 }
 
 void VtkInterface::insert_zero_uStrGrid()

--- a/src/aegis_lib/VtkInterface.cpp
+++ b/src/aegis_lib/VtkInterface.cpp
@@ -51,7 +51,7 @@ void VtkInterface::init(){
   // new_vtkArray("B.n_direction", 1);
   // new_vtkArray("Normal", 3);
   // new_vtkArray("B_field", 3);
-  new_vtkArray("Psi_Start", 1);
+  // new_vtkArray("Psi_Start", 1);
   // new_vtkArray("B.n", 1);
 
   
@@ -166,6 +166,7 @@ void VtkInterface::insert_next_uStrGrid(std::string arrayName, std::vector<doubl
 
 void VtkInterface::insert_next_uStrGrid(std::string arrayName, double valueToAdd){
   arrays[arrayName]->InsertNextTuple1(valueToAdd);
+  std::cout << valueToAdd << std::endl;
 }
 
 void VtkInterface::insert_zero_uStrGrid()

--- a/src/aegis_lib/VtkInterface.h
+++ b/src/aegis_lib/VtkInterface.h
@@ -30,29 +30,19 @@ class VtkInterface : public AegisBase
   void init_Ptrack_branch(std::string branchName);
   void init(); // initialise unstructured grid and particle tracks multiblock
   vtkNew<vtkPolyData> new_track(std::string branchName, vtkSmartPointer<vtkPoints> points, double heatflux);
-  void new_vtkArray(std::string arrName, int nComponents);
-  void add_vtkArrays();
-  void write_unstructuredGrid(std::string fileName);
   void write_particle_track(std::string branchName, double heatflux);
   void write_multiBlockData(std::string fileName);
-  void insert_next_uStrGrid(std::string arrayName, std::vector<double> valuesToAdd);
-  void insert_next_uStrGrid(std::string arrayName, double valueToAdd);
-  void insert_zero_uStrGrid();
   void init_new_vtkPoints();
   void insert_next_point_in_track(std::vector<double> pointsToAdd);  
-  void mpi_write_uStrGrid(std::string vtk_input_file, std::vector<double> heatfluxVector);
 
 
   private:
-  std::unordered_map<std::string, vtkSmartPointer<vtkDoubleArray>> arrays; ; // map of vtkDoubleArrays
   int vtkPointCounter;
   std::map<std::string, vtkSmartPointer<vtkMultiBlockDataSet>> particleTracks;
   vtkSmartPointer<vtkMultiBlockDataSet> multiBlockRoot;
   vtkSmartPointer<vtkMultiBlockDataSet> multiBlockBranch;
-  vtkSmartPointer<vtkUnstructuredGrid> unstructuredGrid;
   std::map<std::string, int> multiBlockCounters; // map of various counters for each branch
   vtkSmartPointer<vtkPoints> particleTrackPoints;
-  std::string vtk_input_file;
   bool drawParticleTracks = false;
 
 };

--- a/src/aegis_lib/VtkInterface.h
+++ b/src/aegis_lib/VtkInterface.h
@@ -19,10 +19,10 @@
 #include <vtkUnstructuredGridReader.h>
 #include <vtkUnstructuredGridWriter.h>
 #include <vtkAppendFilter.h>
+#include "Inputs.h"
+#include "AegisBase.h"
 
-#include <Inputs.h>
-
-class VtkInterface
+class VtkInterface : public AegisBase
 {
   public:
   VtkInterface(const std::shared_ptr<InputJSON> &JSONsettings);

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -8,6 +8,7 @@ target_include_directories(unit_tests PUBLIC ${PROJECT_SOURCE_DIR}/src/${PROJECT
 target_include_directories(unit_tests PUBLIC ${DAGMC_INCLUDE_DIRS})
 target_include_directories(unit_tests PUBLIC ${VTK_LIBRARIES})
 
+target_link_libraries(unit_tests ${Boost_LIBRARIES})
 target_link_libraries(unit_tests ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY} pthread)
 target_link_libraries(unit_tests ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${PROJECT_NAME}.so)
 target_link_libraries(unit_tests ${DAGMC_LIBRARY} dagmc-shared uwuw-shared )

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(unit_tests ${Boost_LIBRARIES})
 target_link_libraries(unit_tests ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY} pthread)
 target_link_libraries(unit_tests ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${PROJECT_NAME}.so)
 target_link_libraries(unit_tests ${DAGMC_LIBRARY} dagmc-shared uwuw-shared )
-target_link_libraries(unit_tests ${VTK_LIBRARIES})
+target_link_libraries(unit_tests ${VTK_LIBRARIES}) 
 
 include(GoogleTest)
 gtest_discover_tests(unit_tests WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/test/data")

--- a/test/unit/aegis_unit.cpp
+++ b/test/unit/aegis_unit.cpp
@@ -11,6 +11,7 @@
 #include "Integrator.h"
 #include "Source.h"
 #include "CoordTransform.h"
+#include "SimpleLogger.h"
  
 using namespace moab;
 


### PR DESCRIPTION
**TL:DR - Implemented working functions that use MPI_Gather to perform parallelised simulation**

This started off as an attempt to get a dynamic task farm type approach working. So some WIP code for that has been put in place but it is currently broken and not finished. Following on from that, a function to get the coordinates of the set of nodes that define the implicit complement was also added - this is still a WIP. Following, was replacing `vtk` to produce heatflux distribution outputs with using MOAB directly with the use of `Tags`. Finally the big takeaway was getting a working parallel speedup (~5x) with two implementations `ParticleSimulation::Execute_mpi_padded() and `ParticleSimulation::Execute_mpi()`, making use of `MPI_Gather` and `MPI_Gatherv` respectively. Comprehensive change notes below:

Changes
-
- Now there are four methods to perform a particle simulation with AEGIS. Serial (`Execute()`), dynamic task farm (`Execute_dynamic_mpi()`), MPI_Gather (`Execute_padded_mpi()`) and MPI_Gatherv (`Execute_mpi()`). These represent different approaches to solving the parallelisation problem. All of them will continue to exist to give me more stuff to talk about in my Cranfield project report.
- Added a check to aegis main function that calls a serial execute if only one process detected. Now that there is a working MPI_Gather implementation this serial execute is probably redundant as the parallel execute with one process should essentially be the same as the serial. This check was initially put in as the task farm approach required at least 2 processes.
- Introduction of a new base class `AegisBase`. All aegis classes now inherit from this class which provides them with some helper functions for printing/logging on a single MPI_rank. Currently the class lacks much else but in the future should I wish to add some capability to every aegis class this will be the place to do it.
- All statements that print to terminal now only print to rank 0 across all aegis functions. The new method `AegisBase::log_string` or `AegisBase::mpi_print()` can be used to ensure all future prints to log and/or terminal happen on a single MPI rank.
- New counters added to `SurfaceIntegrator` to track the number of padded null particles, in case I do wish to carry on with using a padded MPI approach.
- Some attempts were made to reduce the number of `DagMC::ray_fire()` calls by making use of `DagMC::closest_to_location()` which returns the euclidian distance to the nearest surface from a position. The idea being to call this function every so often and set a "safety threshold" that until a particle exceeds, there would be no need to call `DagMC::ray_fire()`. Two new methods `ParticleBase::set_intersection_threshold` and `ParticleBase::check_if_threshold_crossed()` handle this. This current implementation resulted in very marginally fewer `ray_fire()` calls and actually caused aegis runtime to increase. So for now this idea has been shelved.
-  Removed now unnecessary vtk methods associated with producing a heatflux distribution output
- Currently disabled some unit tests.