### PR TITLE
fixed the issue causing memory to run out

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ include_directories(externals/json/include)
 
 # Default to cpmpile with debugging symbols
 set(CMAKE_BUILD_TYPE DEBUG)
-#set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
-#set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+# set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+# set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
 # set(BUILD_TYPE "PROFILING")
 # set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pg")
 # set (CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -pg")

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -7,7 +7,7 @@
       "launch_pos": "fixed",
       "target_surfs": [1,2,3,4,5,6],
       "force_no_deposition": false,
-      "dynamic_task_size": 32,
+      "dynamic_task_size": 25,
       "coordinate_system": "flux",
       "execution_type": "dynamic"
   },
@@ -21,7 +21,7 @@
       "rmove": -0.006,
       "draw_equil_rz": false,
       "draw_equil_xyz": false,
-      "print_debug_info": false
+      "print_debug_info": true
   },
   "vtk_params":{
       "VTK": "target_facets.stl",

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -105,9 +105,9 @@ class ParticleSimulation : public AegisBase
   void polar_track();
   void flux_track();
   
-  terminationState loop_over_particle_track(TriangleSource&tri, ParticleBase &particle, DagMC::RayHistory &history); // loop over individual particle tracks
+  terminationState loop_over_particle_track(TriangleSource&tri, std::unique_ptr<ParticleBase> &particle, DagMC::RayHistory &history); // loop over individual particle tracks
   void terminate_particle(TriangleSource&facet, DagMC::RayHistory &history, terminationState termination); // end particle track
-  void ray_hit_on_launch(ParticleBase &particle, DagMC::RayHistory &history); // particle hit on initial launch from surface
+  void ray_hit_on_launch(std::unique_ptr<ParticleBase> &particle, DagMC::RayHistory &history); // particle hit on initial launch from surface
   void print_particle_stats(std::array<int, 5> particleStats); // print number of particles that reached each termination state
   void mpi_particle_stats(); // get inidividual particle stats for each process
   void read_params(const std::shared_ptr<InputJSON> &inputs); // read parameters from aegis_settings.json


### PR DESCRIPTION
**IMPORTANT BUGFIX**
**Issue is now fixed and memory usage per run is back down to normal**

Was previously having an issue with running out of memory with larger problems making use of dynamic MPI load balancing. In some of the refactoring I had done I had moved a function that was calling std::vector::push_back() to a member variable of  `ParticleSimulation` inside the `worker()` method. So when I would have a small enough batch size and a large enough problem (so the workers would call for work many times) I was constantly adding to the end of this vector leading to the creation of a massive vector which would eat up more and more system memory. 

`valgrind` with the `massif` tool proved to be very useful in diagnosing where large chunks of memory were being allocated. In this case specifically I noticed that memory for this vector was constantly being allocated throughout the program's runtime when it should only be allocated a single time.

-> This suggests some inherent flaws in my current design patterns if something like this can happen accidentally
-> `ParticleSimulation` ideally needs to be broken down into further smaller classes
-> Maybe `worker()` and `handler()` should instead be their own class with other associated methods. Something to think about.
