### PR TITLE
General refactoring to make running on CSD3 easier

### DIFF
--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -7,9 +7,12 @@
       "launch_pos": "fixed",
       "target_surfs": [1,2,3,4,5,6],
       "force_no_deposition": false,
-      "dynamic_task_size": 25,
       "coordinate_system": "flux",
-      "execution_type": "dynamic"
+      "execution_type": "dynamic",
+      "task_farm_params":{
+          "dynamic_task_size": 50,
+          "worker_profiling_enabled": false        
+      } 
   },
   "equil_params":{
       "eqdsk": "EQ3.eqdsk",
@@ -24,7 +27,6 @@
       "print_debug_info": true
   },
   "vtk_params":{
-      "VTK": "target_facets.stl",
-      "draw_particle_tracks": true
+      "draw_particle_tracks": false
   }
  }

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -1,7 +1,7 @@
 {
   "description": "inres1 test case to compare against SMARDDA",
   "aegis_params":{
-      "DAGMC": "inres1_shad.h5m",
+      "DAGMC": "weak_scaling/inres1_start_scaling.h5m",
       "step_size": 0.005,
       "max_steps": 100000,
       "launch_pos": "fixed",
@@ -10,7 +10,7 @@
       "coordinate_system": "flux",
       "execution_type": "dynamic",
       "task_farm_params":{
-          "dynamic_task_size": 50,
+          "dynamic_task_size": 16,
           "worker_profiling_enabled": false        
       } 
   },
@@ -24,9 +24,9 @@
       "rmove": -0.006,
       "draw_equil_rz": false,
       "draw_equil_xyz": false,
-      "print_debug_info": true
+      "print_debug_info": false
   },
   "vtk_params":{
-      "draw_particle_tracks": false
+      "draw_particle_tracks": true
   }
  }

--- a/src/aegis_lib/AegisBase.cpp
+++ b/src/aegis_lib/AegisBase.cpp
@@ -27,7 +27,7 @@ AegisBase::print_mpi(std::string inString)
   }
 }
 
-// wrapper for boost LOG macros to test for MPI rank
+// wrapper for boost LOG macros that only prints on rank 0
 void
 AegisBase::log_string(LogLevel level, std::string inString)
 {
@@ -59,6 +59,10 @@ AegisBase::log_string(LogLevel level, std::string inString)
       default:
         LOG_WARNING << inString;
     }
+  }
+  else
+  {
+    return;
   }
 }
 

--- a/src/aegis_lib/EquilData.cpp
+++ b/src/aegis_lib/EquilData.cpp
@@ -1393,23 +1393,6 @@ EquilData::get_midplane_params()
   return midplaneParams;
 }
 
-// void EquilData::set_omp()
-// {
-//   // Ensure EquilData::centre() has been called first so R,Z values of centre
-//   known if (rcen == 0 && zcen == 0)
-//   {
-//     LOG_ERROR << "Values RCEN and ZCEN are not set. Ensure these are set
-//     before attempting to
-//                   define outer-midplane";
-//   }
-
-//   else
-//   {
-//     std::vector
-//   }
-
-// }
-
 // check if in b_field from polar coords (R,Z)
 void
 EquilData::check_if_in_bfield(std::vector<double> xyzPos)

--- a/src/aegis_lib/EquilData.cpp
+++ b/src/aegis_lib/EquilData.cpp
@@ -821,19 +821,17 @@ EquilData::b_field(std::vector<double> position, std::string startingFrom)
   {
     return {};
   }
-  else
-  {
-    // evaluate psi and psi derivs at given (R,Z) coords
-    alglib::spline2ddiff(psiSpline, zr, zz, zpsi, zdpdr, zdpdz, null);
 
-    // evaluate I aka f at psi (I aka f is the flux function)
-    zf = alglib::spline1dcalc(fSpline, zpsi);
+  // evaluate psi and psi derivs at given (R,Z) coords
+  alglib::spline2ddiff(psiSpline, zr, zz, zpsi, zdpdr, zdpdz, null);
 
-    // calculate B in cylindrical toroidal polars
-    bVector[0] = -zdpdz / zr; // B_R
-    bVector[1] = zdpdr / zr;  // B_Z
-    bVector[2] = zf / zr;     // B_T - toroidal component of field directed along phi
-  }
+  // evaluate I aka f at psi (I aka f is the flux function)
+  zf = alglib::spline1dcalc(fSpline, zpsi);
+
+  // calculate B in cylindrical toroidal polars
+  bVector[0] = -zdpdz / zr; // B_R
+  bVector[1] = zdpdr / zr;  // B_Z
+  bVector[2] = zf / zr;     // B_T - toroidal component of field directed along phi
 
   // return the calculated B vector
   return bVector;
@@ -1339,7 +1337,7 @@ EquilData::psi_limiter(std::vector<std::vector<double>> vertices)
   bpbdry = zbpbdry;
   btotbdry = zbtotbdry;
 
-  if (rank == 0)
+  if (rank == 0 && debug)
   {
     std::cout << "PSI_LIMITER() RBDRY = " << rbdry << std::endl;
     std::cout << "PSI_LIMITER() BPBDRY = " << bpbdry << std::endl;
@@ -1411,3 +1409,16 @@ EquilData::get_midplane_params()
 //   }
 
 // }
+
+// check if in b_field from polar coords (R,Z)
+void
+EquilData::check_if_in_bfield(std::vector<double> xyzPos)
+{
+  std::vector<double> polarPos = CoordTransform::cart_to_polar(xyzPos, "forwards");
+  double r = polarPos[0];
+  double z = polarPos[1];
+  if (r < rmin || r > rmax || z < zmin || z > zmax)
+  {
+    throw std::runtime_error("Position outside magnetic field");
+  }
+}

--- a/src/aegis_lib/EquilData.h
+++ b/src/aegis_lib/EquilData.h
@@ -131,6 +131,8 @@ class EquilData : public AegisBase
 
   void psiref_override();
 
+  void check_if_in_bfield(std::vector<double> xyzPos);
+
   std::array<double, 3> get_midplane_params(); // return rInnerMidplane, rOuterMidplane, zMidplane
 
   // override for ITER corrections to eqdsk

--- a/src/aegis_lib/Integrator.h
+++ b/src/aegis_lib/Integrator.h
@@ -38,7 +38,13 @@ struct comp
 typedef std::set<std::pair<EntityHandle, int>, comp> int_sorted_map;
 typedef std::set<std::pair<EntityHandle, double>, comp> dbl_sorted_map;
 
-
+// terminate particle depending on 1 of 4 termination states:
+//
+// DEPOSITING - Particle reaches outer midplane and deposits power on facet.
+// Heatflux = Q SHADOWED - Particle hits another piece of geometry. Heatflux = 0
+// LOST - Particle leaves magnetic field so trace stops. Heatflux = 0
+// MAX LENGTH - Particle reaches maximum user set length before anything else.
+// Heatflux = 0
 enum class terminationState{
 DEPOSITING, // midplane reached 
 SHADOWED, // shadow geometry hit

--- a/src/aegis_lib/ParticleSimulation.cpp
+++ b/src/aegis_lib/ParticleSimulation.cpp
@@ -379,10 +379,8 @@ ParticleSimulation::init_geometry()
   nodeCoords.resize(nodesList.size() * 3);
   DAG->moab_instance()->get_coords(&nodesList[0], nodesList.size(), nodeCoords.data());
 
-  if (rank == 0)
-  {
-    std::cout << "Number of Triangles in Geometry " << facetsList.size() << std::endl;
-  }
+  totalNumberOfFacets = facetsList.size();
+
   implComplementVol = DAG->entity_by_index(3, volsList.size());
 
   if (!DAG->is_implicit_complement(implComplementVol))
@@ -448,7 +446,20 @@ ParticleSimulation::loop_over_facets(int startFacet, int endFacet)
       continue;
     }
 
+    DagMC::RayHistory history;
     auto particle = std::make_unique<ParticleBase>(coordSys);
+
+    try
+    {
+      equilibrium->check_if_in_bfield(tri.launch_pos());
+    }
+    catch (std::runtime_error & e)
+    {
+      log_string(LogLevel::INFO, "Particle start out of bounds. Skipping to next triangle...");
+      terminate_particle_lost(tri);
+      continue;
+    }
+
     particle->set_pos(tri.launch_pos());
 
     integrator->set_launch_position(tri.entity_handle(), tri.launch_pos());
@@ -461,7 +472,6 @@ ParticleSimulation::loop_over_facets(int startFacet, int endFacet)
     particle->align_dir_to_surf(tri.BdotN());
 
     // Start ray tracing
-    DagMC::RayHistory history;
     trackLength = trackStepSize;
 
     particle->update_vectors(trackStepSize, equilibrium);
@@ -545,7 +555,7 @@ ParticleSimulation::loop_over_particle_track(TriangleSource & tri,
     if (nextSurf != 0)
     {
       particle->update_vectors(nextSurfDist); // update position to surface intersection point
-      terminate_particle(tri, history, terminationState::SHADOWED);
+      terminate_particle_shadow(tri, history);
       return terminationState::SHADOWED;
     }
     else
@@ -554,29 +564,30 @@ ParticleSimulation::loop_over_particle_track(TriangleSource & tri,
     }
 
     vtkInterface->insert_next_point_in_track(particle->posXYZ);
-    equilibrium->check_if_in_bfield(particle->posXYZ);
-    if (particle->outOfBounds)
-    {
-      terminate_particle(tri, history, terminationState::LOST);
-      return terminationState::LOST;
-    }
 
-    else
+    try
     {
+      equilibrium->check_if_in_bfield(particle->posXYZ);
       particle->set_dir(equilibrium);
       particle->align_dir_to_surf(tri.BdotN());
     }
+    catch (std::runtime_error & e)
+    {
+      terminate_particle_lost(tri);
+      return terminationState::LOST;
+    }
+
     particle->check_if_midplane_crossed(equilibrium->get_midplane_params());
 
     if (particle->atMidplane != 0 && !noMidplaneTermination)
     {
-      terminate_particle(tri, history, terminationState::DEPOSITING);
+      terminate_particle_depositing(tri);
       return terminationState::DEPOSITING;
     }
 
     if (step == (maxTrackSteps - 1))
     {
-      terminate_particle(tri, history, terminationState::MAXLENGTH);
+      terminate_particle_maxlength(tri);
       return terminationState::MAXLENGTH;
     }
   }
@@ -584,51 +595,54 @@ ParticleSimulation::loop_over_particle_track(TriangleSource & tri,
   return terminationState::LOST; // default return lost particle
 }
 
-// terminate particle depending on 1 of 4 termination states:
-//
-// DEPOSITING - Particle reaches outer midplane and deposits power on facet.
-// Heatflux = Q SHADOWED - Particle hits another piece of geometry. Heatflux = 0
-// LOST - Particle leaves magnetic field so trace stops. Heatflux = 0
-// MAX LENGTH - Particle reaches maximum user set length before anything else.
-// Heatflux = 0
+// terminate particle after reaching midplane
 void
-ParticleSimulation::terminate_particle(TriangleSource & tri, DagMC::RayHistory & history,
-                                       terminationState termination)
+ParticleSimulation::terminate_particle_depositing(TriangleSource & tri)
 {
-  double heatflux;
-  std::stringstream ss;
+  std::stringstream terminationLogString;
+  double heatflux = tri.heatflux();
+  vtkInterface->write_particle_track(branchDepositingPart, heatflux);
+  integrator->count_particle(tri.entity_handle(), terminationState::DEPOSITING, heatflux);
+  terminationLogString << "Midplane reached. Depositing power after travelling " << trackLength
+                       << " units";
+  log_string(LogLevel::INFO, terminationLogString.str());
+}
 
-  switch (termination)
-  {
-    case terminationState::DEPOSITING:
-      heatflux = tri.heatflux();
-      vtkInterface->write_particle_track(branchDepositingPart, heatflux);
-      integrator->count_particle(tri.entity_handle(), termination, heatflux);
-      log_string(LogLevel::INFO, "Midplane reached. Depositing power");
-      break;
+// terminate particle after hitting shadowing geometry
+void
+ParticleSimulation::terminate_particle_shadow(TriangleSource & tri, DagMC::RayHistory & history)
+{
+  std::stringstream terminationLogString;
+  double heatflux = 0.0;
+  vtkInterface->write_particle_track(branchShadowedPart, heatflux);
+  integrator->count_particle(tri.entity_handle(), terminationState::SHADOWED, heatflux);
+  terminationLogString << "Surface " << nextSurf << " hit after travelling " << trackLength
+                       << " units";
+  log_string(LogLevel::INFO, terminationLogString.str());
+}
 
-    case terminationState::SHADOWED:
-      heatflux = 0.0;
-      history.get_last_intersection(intersectedFacet);
-      vtkInterface->write_particle_track(branchShadowedPart, heatflux);
-      integrator->count_particle(tri.entity_handle(), termination, heatflux);
-      ss << "Surface " << nextSurf << " hit after travelling " << trackLength << " units";
-      log_string(LogLevel::INFO, ss.str());
-      break;
+// terminate particle after leaving magnetic field
+void
+ParticleSimulation::terminate_particle_lost(TriangleSource & tri)
+{
+  std::stringstream terminationLogString;
+  double heatflux = 0.0;
+  vtkInterface->write_particle_track(branchLostPart, heatflux);
+  integrator->count_particle(tri.entity_handle(), terminationState::LOST, heatflux);
+  terminationLogString << "Particle leaving magnetic field after travelling " << trackLength
+                       << " units";
+  log_string(LogLevel::INFO, terminationLogString.str());
+}
 
-    case terminationState::LOST:
-      heatflux = 0.0;
-      vtkInterface->write_particle_track(branchLostPart, heatflux);
-      integrator->count_particle(tri.entity_handle(), termination, heatflux);
-      log_string(LogLevel::INFO, "TRACE STOPPED BECAUSE LEAVING MAGNETIC FIELD");
-      break;
-
-    case terminationState::MAXLENGTH:
-      heatflux = 0.0;
-      vtkInterface->write_particle_track(branchMaxLengthPart, heatflux);
-      integrator->count_particle(tri.entity_handle(), termination, heatflux);
-      log_string(LogLevel::INFO, "Fieldline trace reached maximum length before intersection");
-  }
+// terminate particle after travelling user specified max distance
+void
+ParticleSimulation::terminate_particle_maxlength(TriangleSource & tri)
+{
+  std::stringstream terminationLogString;
+  double heatflux = 0.0;
+  vtkInterface->write_particle_track(branchMaxLengthPart, heatflux);
+  integrator->count_particle(tri.entity_handle(), terminationState::MAXLENGTH, heatflux);
+  terminationLogString << "Fieldline trace reached maximum length before intersection";
 }
 
 void
@@ -738,17 +752,16 @@ ParticleSimulation::print_particle_stats(std::array<int, 5> particleStats)
 
   if (rank == 0)
   {
-    LOG_WARNING << "Number of particles launched = " << particlesCounted << std::endl;
-    LOG_WARNING << "Number of particles depositing power from omp = " << particleStats[0]
-                << std::endl;
-    LOG_WARNING << "Number of shadowed particle intersections = " << particleStats[1] << std::endl;
-    LOG_WARNING << "Number of particles lost from magnetic domain = " << particleStats[2]
-                << std::endl;
+    LOG_WARNING << "Total number of triangles in geometry (Shadow + Target) = "
+                << totalNumberOfFacets;
+    LOG_WARNING << "Number of particles launched = " << particlesCounted;
+    LOG_WARNING << "Number of particles depositing power from omp = " << particleStats[0];
+    LOG_WARNING << "Number of shadowed particle intersections = " << particleStats[1];
+    LOG_WARNING << "Number of particles lost from magnetic domain = " << particleStats[2];
     LOG_WARNING << "Number of particles terminated upon reaching max tracking length = "
-                << particleStats[3] << std::endl;
-    LOG_WARNING << "Number of padded null particles = " << particleStats[4] << std::endl;
-    LOG_WARNING << "Number of particles not accounted for = " << (num_facets() - particlesCounted)
-                << std::endl;
+                << particleStats[3];
+    LOG_WARNING << "Number of padded null particles = " << particleStats[4];
+    LOG_WARNING << "Number of particles not accounted for = " << (num_facets() - particlesCounted);
   }
   // std::cout << "Number of Ray fire calls = " << numberOfRayFireCalls <<
   // std::endl;
@@ -1080,24 +1093,33 @@ ParticleSimulation::attach_mesh_attribute(const std::string & tagName, moab::Ran
 void
 ParticleSimulation::write_out_mesh(meshWriteOptions option, moab::Range rangeofEntities)
 {
+  // get target meshset for aegis_target outputs
   DAG->remove_graveyard();
   EntityHandle targetMeshset;
   DAG->moab_instance()->create_meshset(MESHSET_SET, targetMeshset);
   DAG->moab_instance()->add_entities(targetMeshset, targetFacets);
 
+  // remove file extension from input file string
+  std::string aegisOut = dagmcInputFile;
+  aegisOut = aegisOut.substr(0, aegisOut.find_last_of("."));
+  aegisOut = aegisOut.substr(aegisOut.find_last_of("/") + 1, aegisOut.length());
+  std::string aegisOutFull = aegisOut + "_aegis_full.vtk";
+  std::string aegisOutTarget = aegisOut + "_aegis_target.vtk";
+  std::string aegisOutPartial = aegisOut + "_aegis_partial.vtk";
+
   switch (option)
   {
     case meshWriteOptions::FULL:
-      DAG->write_mesh("aegis_full.vtk", 1);
+      DAG->write_mesh(aegisOutFull.c_str(), 1);
       break;
 
     case meshWriteOptions::TARGET:
-      DAG->moab_instance()->write_mesh("aegis_target.vtk", &targetMeshset, 1);
+      DAG->moab_instance()->write_mesh(aegisOutTarget.c_str(), &targetMeshset, 1);
       break;
 
     case meshWriteOptions::BOTH:
-      DAG->moab_instance()->write_mesh("aegis_target.vtk", &targetMeshset, 1);
-      DAG->write_mesh("aegis_full.vtk", 1);
+      DAG->moab_instance()->write_mesh(aegisOutTarget.c_str(), &targetMeshset, 1);
+      DAG->write_mesh(aegisOut.c_str(), 1);
       break;
 
     case meshWriteOptions::PARTIAL:
@@ -1106,7 +1128,7 @@ ParticleSimulation::write_out_mesh(meshWriteOptions option, moab::Range rangeofE
         EntityHandle meshset;
         DAG->moab_instance()->create_meshset(MESHSET_SET, meshset);
         DAG->moab_instance()->add_entities(meshset, rangeofEntities);
-        DAG->moab_instance()->write_mesh("aegis_partial.vtk", &meshset, 1);
+        DAG->moab_instance()->write_mesh(aegisOutPartial.c_str(), &meshset, 1);
       }
       else
       {

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -137,6 +137,7 @@ class ParticleSimulation : public AegisBase
   std::string drawParticleTracks;
   int dynamicTaskSize;
   std::string coordInputStr;
+  bool workerProfiling = false;
   coordinateSystem coordSys = coordinateSystem::CARTESIAN; // default cartesian 
 
   double rmove = 0.0;

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -106,7 +106,13 @@ class ParticleSimulation : public AegisBase
   void flux_track();
   
   terminationState loop_over_particle_track(TriangleSource&tri, std::unique_ptr<ParticleBase> &particle, DagMC::RayHistory &history); // loop over individual particle tracks
-  void terminate_particle(TriangleSource&facet, DagMC::RayHistory &history, terminationState termination); // end particle track
+  void terminate_particle_depositing(TriangleSource&tri); // end particle track
+  void terminate_particle_shadow(TriangleSource&tri, DagMC::RayHistory &history); // end particle track
+  void terminate_particle_lost(TriangleSource&tri); // end particle track
+  void terminate_particle_maxlength(TriangleSource&tri); // end particle track
+  
+  
+  
   void ray_hit_on_launch(std::unique_ptr<ParticleBase> &particle, DagMC::RayHistory &history); // particle hit on initial launch from surface
   void print_particle_stats(std::array<int, 5> particleStats); // print number of particles that reached each termination state
   void mpi_particle_stats(); // get inidividual particle stats for each process
@@ -122,6 +128,7 @@ class ParticleSimulation : public AegisBase
   int nFacets;
   
   std::vector<TriangleSource> listOfTriangles;
+  unsigned int totalNumberOfFacets = 0;
 
   std::string settingsFileName;
   std::shared_ptr<InputJSON> JSONsettings; 

--- a/src/aegis_lib/Source.cpp
+++ b/src/aegis_lib/Source.cpp
@@ -104,6 +104,7 @@ Sources::set_heatflux_params(const std::shared_ptr<EquilData> & equilibrium,
   fluxPos = CoordTransform::polar_to_flux(polarPos, "forwards", equilibrium);
 
   bField = equilibrium->b_field(polarPos, "forwards");
+
   bField = equilibrium->b_field_cart(bField, polarPos[2], 0);
   double product = 0;
   for (int i = 0; i < 3; i++)

--- a/src/aegis_lib/VtkInterface.cpp
+++ b/src/aegis_lib/VtkInterface.cpp
@@ -10,6 +10,13 @@ VtkInterface::VtkInterface(const std::shared_ptr<InputJSON> & inputs)
     vtkNamelist = inputs->data["vtk_params"];
     drawParticleTracks = vtkNamelist["draw_particle_tracks"];
   }
+
+  if (drawParticleTracks)
+  {
+    init_Ptrack_root();
+
+    // log_string(LogLevel::WARNING, "vtkMultiBlockDataSet initialised for particle tracks");
+  }
 }
 
 void
@@ -43,16 +50,6 @@ VtkInterface::init_Ptrack_branch(std::string branchName)
 void
 VtkInterface::init()
 {
-
-  if (drawParticleTracks)
-  {
-    init_Ptrack_root();
-  }
-
-  if (drawParticleTracks && rank == 0)
-  {
-    std::cout << "vtkMultiBlockDataSet initialised for particle tracks" << std::endl;
-  }
 }
 
 vtkNew<vtkPolyData>


### PR DESCRIPTION
Short PR to bring in some changes needed to make running on CSD3 a bit nicer. 

- Removed some obsolete, unused code from `EquilData` and refactored `ParticleSimulation::loop_over_facets()` to make use of a separate function for each termination state instead of just relying on a switch statement.
-  Replaced `ParticleBase::check_if_in_bfield()` with `EquilData::check_if_in_bfield()`. I feel like it made more sense for checking if a particle was in the equilibrium to be done by the class that handles the equilibrium. Also allows the function to be more general (input parameter is a general position so it doesn't necessarily have to be a particle).
- Added some hierarchy to aegis_settings.json to handle parameters associated specifically with a dynamic_mpi run. This sets the precedence to actually make use of the hierarchical nature of the json files.
- Added some exception handling code to handle out of range array calls when particle moves out of magnetic field bounds
- Changed the format of the output file name strings. Aegis will now generate output files with the filename associated with the input. I.e a DAGMC input of `inres1.h5m` will result in an output of `inres1_aegis_target.vtk` or whatever type of output is specified