### PR TITLE
Refactoring and improved JSON parameter handling

### DIFF
--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -1,7 +1,7 @@
 {
   "description": "inres1 test case to compare against SMARDDA",
   "aegis_params":{
-      "DAGMC": "weak_scaling/inres1_start_scaling.h5m",
+      "DAGMC": "inres1_shad.h5m",
       "step_size": 0.005,
       "max_steps": 100000,
       "launch_pos": "fixed",
@@ -27,6 +27,6 @@
       "print_debug_info": false
   },
   "vtk_params":{
-      "draw_particle_tracks": true
+      "draw_particle_tracks": false
   }
  }

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -11,13 +11,14 @@
       "execution_type": "dynamic",
       "dynamic_batch_params":{
           "batch_size":16,
-          "worker_profiling": false        
+          "worker_profiling": false,
+	  "worker_debug":false
       } 
   },
   "equil_params":{
       "eqdsk": "EQ3.eqdsk",
       "cenopt": 2,
-      "P_sol": 7.5e+06,
+      "power_sol": 7.5e+06,
       "lambda_q": 0.012,
       "psiref": -2.1628794,
       "r_outrbdry": 8.07385,

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -12,16 +12,16 @@
       "dynamic_batch_params":{
           "batch_size":16,
           "worker_profiling": false,
-	  "worker_debug":false
+	      "worker_debug":false
       } 
   },
   "equil_params":{
       "eqdsk": "EQ3.eqdsk",
-      "cenopt": 2,
       "power_sol": 7.5e+06,
       "lambda_q": 0.012,
-      "psiref": -2.1628794,
       "r_outrbdry": 8.07385,
+      "cenopt": 2,
+      "psiref": -2.1628794,
       "rmove": -0.006,
       "draw_equil_rz": false,
       "draw_equil_xyz": false,

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -2,16 +2,16 @@
   "description": "inres1 test case to compare against SMARDDA",
   "aegis_params":{
       "DAGMC": "inres1_shad.h5m",
-      "step_size": 0.005,
-      "max_steps": 100000,
+      "step_size": 0.01,
+      "max_steps": 10000,
       "launch_pos": "fixed",
       "target_surfs": [1,2,3,4,5,6],
       "force_no_deposition": false,
       "coordinate_system": "flux",
       "execution_type": "dynamic",
-      "task_farm_params":{
-          "dynamic_task_size": 16,
-          "worker_profiling_enabled": false        
+      "dynamic_batch_params":{
+          "batch_size":16,
+          "worker_profiling": false        
       } 
   },
   "equil_params":{

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -34,8 +34,7 @@ main(int argc, char ** argv)
 
   auto configFile = std::make_shared<JsonHandler>(configFileName);
 
-  auto equilibrium = std::make_shared<EquilData>();
-  equilibrium->setup(configFile);
+  auto equilibrium = std::make_shared<EquilData>(configFile);
   equilibrium->move();
   equilibrium->psiref_override();
   equilibrium->init_interp_splines();

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -1,6 +1,7 @@
 #include "ParticleSimulation.h"
 #include <cstdio>
 #include <cstring>
+#include <vector>
 #include <mpi.h>
 #include <unistd.h>
 
@@ -31,7 +32,7 @@ main(int argc, char ** argv)
     configFileName = "aegis_settings.json";
   }
 
-  auto configFile = std::make_shared<InputJSON>(configFileName);
+  auto configFile = std::make_shared<JsonHandler>(configFileName);
 
   auto equilibrium = std::make_shared<EquilData>();
   equilibrium->setup(configFile);

--- a/src/aegis_lib/AegisBase.cpp
+++ b/src/aegis_lib/AegisBase.cpp
@@ -1,18 +1,20 @@
 #include "AegisBase.h"
 #include <mpi.h>
 
-// print error message and MPI_Finalize() exit out of code
+// print error message and MPI_Abort() exit out of code
 void
-AegisBase::error_exit_mpi(std::string inString, std::string file, std::string func, int line,
-                          int rank)
+AegisBase::error_abort_mpi()
 {
-  std::cout << file << ":" << func << ":" << line << ":RANK[" << rank << "] --- " << inString
+  std::cerr << "Terminating program... \n";
+  MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+}
+
+void
+AegisBase::debug_error_exit(std::string errorString, char * file, char * func, int line, int rank)
+{
+  std::cout << file << ":" << func << ":" << line << ":RANK[" << rank << "] --- " << errorString
             << std::endl;
-  if (MPI_Finalize() != MPI_SUCCESS)
-  {
-    std::cout << "ERROR: MPI_Finalize != MPI_SUCCESS" << std::endl;
-  }
-  std::exit(1);
+  MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
 }
 
 // cout for strings only on rank 0

--- a/src/aegis_lib/AegisBase.h
+++ b/src/aegis_lib/AegisBase.h
@@ -36,7 +36,9 @@ class AegisBase
   public:
 
   protected:
-  void error_exit_mpi(std::string inString, std::string file, std::string func, int line, int rank);
+  void error_abort_mpi();
+  void debug_error_exit(std::string errorString, char *file, char *func, int line,
+                          int rank);
   void print_mpi(std::string inString);
   void log_string(LogLevel level, std::string inString);
   void set_mpi_params();

--- a/src/aegis_lib/CoordTransform.cpp
+++ b/src/aegis_lib/CoordTransform.cpp
@@ -9,7 +9,7 @@
 #include "SimpleLogger.h"
 
 std::vector<double>
-CoordTransform::cart_to_polar(std::vector<double> inputVector, std::string direction)
+CoordTransform::cart_to_polar(std::vector<double> inputVector)
 {
   std::vector<double> outputVector(3);
   double r;   // polar r
@@ -18,38 +18,21 @@ CoordTransform::cart_to_polar(std::vector<double> inputVector, std::string direc
   double y;   // cart y
   double z;   // cart z
 
-  if (direction == "backwards")
-  {
-    r = inputVector[0];
-    z = inputVector[1];
-    phi = inputVector[2];
+  x = inputVector[0];
+  y = inputVector[1];
+  z = inputVector[2];
 
-    x = r * cos(phi); // calculate x
+  r = sqrt(pow(x, 2) + pow(y, 2)); // calculate
+  phi = atan2(-y, x);              // calculate phi
 
-    y = -r * sin(phi); // calculate y
-
-    outputVector[0] = x;
-    outputVector[1] = y;
-    outputVector[2] = z;
-  }
-  else
-  {
-    x = inputVector[0];
-    y = inputVector[1];
-    z = inputVector[2];
-
-    r = sqrt(pow(x, 2) + pow(y, 2)); // calculate
-    phi = atan2(-y, x);              // calculate phi
-
-    outputVector[0] = r;
-    outputVector[1] = z;
-    outputVector[2] = phi;
-  }
+  outputVector[0] = r;
+  outputVector[1] = z;
+  outputVector[2] = phi;
   return outputVector;
 }
 
 std::vector<double>
-CoordTransform::cart_to_polar(double e0, double e1, double e2, std::string direction)
+CoordTransform::polar_to_cart(std::vector<double> inputVector)
 {
   std::vector<double> outputVector(3);
   double r;   // polar r
@@ -58,38 +41,69 @@ CoordTransform::cart_to_polar(double e0, double e1, double e2, std::string direc
   double y;   // cart y
   double z;   // cart z
 
-  if (direction == "backwards")
-  {
-    r = e0;
-    z = e1;
-    phi = e2;
+  r = inputVector[0];
+  z = inputVector[1];
+  phi = inputVector[2];
 
-    x = r * cos(phi); // calculate x
+  x = r * cos(phi);  // calculate x
+  y = -r * sin(phi); // calculate y
 
-    y = -r * sin(phi); // calculate y
+  outputVector[0] = x;
+  outputVector[1] = y;
+  outputVector[2] = z;
 
-    outputVector[0] = x;
-    outputVector[1] = y;
-    outputVector[2] = z;
-  }
-  else
-  {
-    x = e0;
-    y = e1;
-    z = e2;
-
-    r = sqrt(pow(x, 2) + pow(y, 2)); // calculate
-    phi = atan2(-y, x);              // calculate phi
-
-    outputVector[0] = r;
-    outputVector[1] = z;
-    outputVector[2] = phi;
-  }
   return outputVector;
 }
 
 std::vector<double>
-CoordTransform::polar_to_flux(std::vector<double> inputVector, std::string direction,
+CoordTransform::cart_to_polar(double e0, double e1, double e2)
+{
+  std::vector<double> outputVector(3);
+  double r;   // polar r
+  double phi; // polar phi
+  double x;   // cart x
+  double y;   // cart y
+  double z;   // cart z
+  x = e0;
+  y = e1;
+  z = e2;
+
+  r = sqrt(pow(x, 2) + pow(y, 2)); // calculate
+  phi = atan2(-y, x);              // calculate phi
+
+  outputVector[0] = r;
+  outputVector[1] = z;
+  outputVector[2] = phi;
+  return outputVector;
+}
+
+std::vector<double>
+CoordTransform::polar_to_cart(double e0, double e1, double e2)
+{
+  std::vector<double> outputVector(3);
+  double r;   // polar r
+  double phi; // polar phi
+  double x;   // cart x
+  double y;   // cart y
+  double z;   // cart z
+
+  r = e0;
+  z = e1;
+  phi = e2;
+
+  x = r * cos(phi); // calculate x
+
+  y = -r * sin(phi); // calculate y
+
+  outputVector[0] = x;
+  outputVector[1] = y;
+  outputVector[2] = z;
+
+  return outputVector;
+}
+
+std::vector<double>
+CoordTransform::polar_to_flux(std::vector<double> inputVector,
                               const std::shared_ptr<EquilData> & equilibrium)
 {
   std::vector<double> outputVector(3);
@@ -99,25 +113,16 @@ CoordTransform::polar_to_flux(std::vector<double> inputVector, std::string direc
   double psi;   // local psi
   double theta; // local theta
 
-  if (direction == "backwards") // backwards transform (flux -> polar coords) TODO
-  {
-    psi = inputVector[0];
-    theta = inputVector[1];
-    phi = inputVector[2];
-  }
-  else // fowards transform (polar -> flux coords)
-  {
-    r = inputVector[0];
-    z = inputVector[1];
-    phi = inputVector[2];
+  r = inputVector[0];
+  z = inputVector[1];
+  phi = inputVector[2];
 
-    psi = alglib::spline2dcalc(equilibrium->psiSpline, r, z); // spline interpolation of psi(R,Z)
+  psi = alglib::spline2dcalc(equilibrium->psiSpline, r, z); // spline interpolation of psi(R,Z)
 
-    theta = atan2(z - equilibrium->zcen, r - equilibrium->rcen);
-    if (theta < -M_PI_2)
-    {
-      theta = 2 * M_PI + theta;
-    }
+  theta = atan2(z - equilibrium->zcen, r - equilibrium->rcen);
+  if (theta < -M_PI_2)
+  {
+    theta = 2 * M_PI + theta;
   }
 
   outputVector[0] = -psi;
@@ -127,8 +132,30 @@ CoordTransform::polar_to_flux(std::vector<double> inputVector, std::string direc
   return outputVector;
 }
 
+// TODO
+// std::vector<double>
+// CoordTransform::flux_to_polar(std::vector<double> inputVector,
+//                               const std::shared_ptr<EquilData> & equilibrium)
+// {
+//   std::vector<double> outputVector(3);
+//   double r;     // local polar r
+//   double z;     // local polar z
+//   double phi;   // local polar phi
+//   double psi;   // local psi
+//   double theta; // local theta
+
+//   if (direction == "backwards") // backwards transform (flux -> polar coords)
+//   {
+//     psi = inputVector[0];
+//     theta = inputVector[1];
+//     phi = inputVector[2];
+//   }
+
+//   return outputVector;
+// }
+
 std::vector<double>
-CoordTransform::polar_to_flux(double e0, double e1, double e2, std::string direction,
+CoordTransform::polar_to_flux(double e0, double e1, double e2,
                               const std::shared_ptr<EquilData> & equilibrium)
 {
   std::vector<double> outputVector(3);
@@ -138,25 +165,16 @@ CoordTransform::polar_to_flux(double e0, double e1, double e2, std::string direc
   double psi;   // local psi
   double theta; // local theta
 
-  if (direction == "backwards") // backwards transform (flux -> polar coords) TODO
-  {
-    psi = e0;
-    theta = e1;
-    phi = e2;
-  }
-  else // fowards transform (polar -> flux coords)
-  {
-    r = e0;
-    z = e1;
-    phi = e2;
+  r = e0;
+  z = e1;
+  phi = e2;
 
-    psi = alglib::spline2dcalc(equilibrium->psiSpline, r, z); // spline interpolation of psi(R,Z)
+  psi = alglib::spline2dcalc(equilibrium->psiSpline, r, z); // spline interpolation of psi(R,Z)
 
-    theta = atan2(z - equilibrium->zcen, r - equilibrium->rcen);
-    if (theta < -M_PI_2)
-    {
-      theta = 2 * M_PI + theta;
-    }
+  theta = atan2(z - equilibrium->zcen, r - equilibrium->rcen);
+  if (theta < -M_PI_2)
+  {
+    theta = 2 * M_PI + theta;
   }
 
   outputVector[0] = -psi;

--- a/src/aegis_lib/CoordTransform.h
+++ b/src/aegis_lib/CoordTransform.h
@@ -12,14 +12,16 @@ namespace CoordTransform
 
 
 // Cartesian to polar toroidal (direction = "backwards" for polar->cartesian)
-std::vector<double> cart_to_polar(std::vector<double> inputVector,
-                                  std::string direction);
-std::vector<double> cart_to_polar(double e0, double e1, double e2, std::string direction);
+std::vector<double> cart_to_polar(std::vector<double> inputVector);
+std::vector<double> cart_to_polar(double e0, double e1, double e2);
+
+std::vector<double> polar_to_cart(std::vector<double> inputVector);
+std::vector<double> polar_to_cart(double e0, double e1, double e2);
 
 // Polar toroidal to flux coordinates defined by psi spline
-std::vector<double> polar_to_flux(std::vector<double> inputVector, std::string direction,
+std::vector<double> polar_to_flux(std::vector<double> inputVector,
                                   const std::shared_ptr<EquilData>& equilibrium);
-std::vector<double> polar_to_flux(double e0, double e1, double e2, std::string direction, const std::shared_ptr<EquilData>& equilibrium);
+std::vector<double> polar_to_flux(double e0, double e1, double e2, const std::shared_ptr<EquilData>& equilibrium);
 };
 
 #endif

--- a/src/aegis_lib/EquilData.cpp
+++ b/src/aegis_lib/EquilData.cpp
@@ -18,10 +18,7 @@ EquilData::EquilData(const std::shared_ptr<JsonHandler> & configFile)
   if (configFile->data().contains("equil_params"))
   {
     set_mpi_params();
-    auto equilParamsData = configFile->data()["equil_params"];
-    JsonHandler equilParams(equilParamsData);
-    read_required_params(equilParamsData);
-    read_optional_params(equilParams);
+    read_params(configFile);
     read_eqdsk(eqdskFilepath);
   }
   else
@@ -35,65 +32,29 @@ EquilData::EquilData(const std::shared_ptr<JsonHandler> & configFile)
 EquilData::EquilData() { set_mpi_params(); }
 
 void
-EquilData::read_optional_params(JsonHandler & equilParams)
+EquilData::read_params(const std::shared_ptr<JsonHandler> & configFile)
 {
-  cenopt = equilParams.get_optional<int>("cenopt").value_or(cenopt);
-  psiref = equilParams.get_optional<double>("psiref").value_or(psiref);
-  rmove = equilParams.get_optional<double>("rmove").value_or(rmove);
-  drawEquRZ = equilParams.get_optional<bool>("draw_equil_rz").value_or(drawEquRZ);
-  drawEquXYZ = equilParams.get_optional<bool>("draw_equil_xyz").value_or(drawEquXYZ);
-  debug = equilParams.get_optional<bool>("debug").value_or(debug);
-}
+  if (configFile->data().contains("equil_params"))
+  {
+    auto equilParamsData = configFile->data()["equil_params"];
+    JsonHandler equilParams(equilParamsData);
+    // get required parameters
+    eqdskFilepath = equilParams.get_required<std::string>("eqdsk");
+    powerSOL = equilParams.get_required<double>("power_sol");
+    lambdaQ = equilParams.get_required<double>("lambda_q");
+    rOutrBdry = equilParams.get_required<double>("r_outrbdry");
 
-void
-EquilData::read_required_params(json & equilParamsData)
-{
-  try
-  {
-    eqdskFilepath = equilParamsData["eqdsk"];
+    // get optional parameters
+    cenopt = equilParams.get_optional<int>("cenopt").value_or(cenopt);
+    psiref = equilParams.get_optional<double>("psiref").value_or(psiref);
+    rmove = equilParams.get_optional<double>("rmove").value_or(rmove);
+    drawEquRZ = equilParams.get_optional<bool>("draw_equil_rz").value_or(drawEquRZ);
+    drawEquXYZ = equilParams.get_optional<bool>("draw_equil_xyz").value_or(drawEquXYZ);
+    debug = equilParams.get_optional<bool>("debug").value_or(debug);
   }
-  catch (const std::exception & e)
+  else
   {
-    std::cerr << e.what() << '\n';
-    std::cerr << "Check config file. Missing required parameter: 'eqdsk' \n \n";
-    std::cerr << "Terminating program... \n";
-    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
-  }
-
-  try
-  {
-    powerSOL = equilParamsData["power_sol"];
-  }
-  catch (const std::exception & e)
-  {
-    std::cerr << e.what() << '\n';
-    std::cerr << "Check config file. Missing required parameter: 'power_sol' \n \n";
-    std::cerr << "Terminating program... \n";
-    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
-  }
-
-  try
-  {
-    lambdaQ = equilParamsData["lambda_q"];
-  }
-  catch (const std::exception & e)
-  {
-    std::cerr << e.what() << '\n';
-    std::cerr << "Check config file. Missing required parameter: 'lambda_q' \n \n";
-    std::cerr << "Terminating program... \n";
-    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
-  }
-
-  try
-  {
-    rOutrBdry = equilParamsData["r_outrbdry"];
-  }
-  catch (const std::exception & e)
-  {
-    std::cerr << e.what() << '\n';
-    std::cerr << "Check config file. Missing required parameter: 'r_outrbdry' \n \n";
-    std::cerr << "Terminating program... \n";
-    MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
+    std::cerr << "JSON file missing equil_params block";
   }
 }
 

--- a/src/aegis_lib/EquilData.cpp
+++ b/src/aegis_lib/EquilData.cpp
@@ -17,6 +17,7 @@ EquilData::EquilData(const std::shared_ptr<JsonHandler> & configFile)
 {
   if (configFile->data().contains("equil_params"))
   {
+    set_mpi_params();
     auto equilParamsData = configFile->data()["equil_params"];
     JsonHandler equilParams(equilParamsData);
     read_required_params(equilParamsData);
@@ -31,7 +32,7 @@ EquilData::EquilData(const std::shared_ptr<JsonHandler> & configFile)
   }
 }
 
-EquilData::EquilData() {}
+EquilData::EquilData() { set_mpi_params(); }
 
 void
 EquilData::read_optional_params(JsonHandler & equilParams)

--- a/src/aegis_lib/EquilData.cpp
+++ b/src/aegis_lib/EquilData.cpp
@@ -14,16 +14,16 @@
 #include <mpi.h>
 
 void
-EquilData::setup(const std::shared_ptr<InputJSON> & inputs)
+EquilData::setup(const std::shared_ptr<JsonHandler> & inputs)
 {
 
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
 
   json equilNamelist;
-  if (inputs->data.contains("equil_params"))
+  if (inputs->data().contains("equil_params"))
   {
-    equilNamelist = inputs->data["equil_params"];
+    equilNamelist = inputs->data()["equil_params"];
     eqdskFilepath = equilNamelist["eqdsk"];
     cenopt = equilNamelist["cenopt"];
     powerSOL = equilNamelist["P_sol"];
@@ -812,7 +812,7 @@ EquilData::b_field(std::vector<double> position, std::string startingFrom)
   else
   {
     std::vector<double> polarPosition;
-    polarPosition = CoordTransform::cart_to_polar(position, "forwards");
+    polarPosition = CoordTransform::cart_to_polar(position);
     zr = polarPosition[0];
     zz = polarPosition[1];
   }
@@ -944,10 +944,9 @@ EquilData::write_bfield(int phiSamples)
             log_string(LogLevel::ERROR, "Negative R Values when attempting plot magnetic field. "
                                         "Fixup eqdsk required");
           }
-          polarB = b_field(polarPos, "polar");          // calculate B(R,Z,phi)
-          cartB = b_field_cart(polarB, polarPos[2], 0); // transform to B(x,y,z)
-          cartPos = CoordTransform::cart_to_polar(polarPos,
-                                                  "backwards"); // transform position to cartesian
+          polarB = b_field(polarPos, "polar");               // calculate B(R,Z,phi)
+          cartB = b_field_cart(polarB, polarPos[2], 0);      // transform to B(x,y,z)
+          cartPos = CoordTransform::polar_to_cart(polarPos); // transform position to cartesian
 
           // write out magnetic field data for plotting
           if (cartPos[0] > 0)
@@ -1293,7 +1292,7 @@ EquilData::psi_limiter(std::vector<std::vector<double>> vertices)
   for (auto & i : vertices)
   {
     std::vector<double> cartPos = i;
-    std::vector<double> polarPos = CoordTransform::cart_to_polar(i, "forwards");
+    std::vector<double> polarPos = CoordTransform::cart_to_polar(i);
 
     zr = polarPos[0];
     zz = polarPos[1];
@@ -1397,7 +1396,7 @@ EquilData::get_midplane_params()
 void
 EquilData::check_if_in_bfield(std::vector<double> xyzPos)
 {
-  std::vector<double> polarPos = CoordTransform::cart_to_polar(xyzPos, "forwards");
+  std::vector<double> polarPos = CoordTransform::cart_to_polar(xyzPos);
   double r = polarPos[0];
   double z = polarPos[1];
   if (r < rmin || r > rmax || z < zmin || z > zmax)

--- a/src/aegis_lib/EquilData.h
+++ b/src/aegis_lib/EquilData.h
@@ -83,11 +83,9 @@ class EquilData : public AegisBase
   EquilData(const std::shared_ptr<JsonHandler> &configFile);
   EquilData();
 
-  // read required parameters from config file
-  void read_required_params(json &EquilDataParams);
   
-  // read optional parameters from config file
-  void read_optional_params(JsonHandler &EquilParams);
+  // read parameters from json file
+  void read_params(const std::shared_ptr<JsonHandler> & configFile);
 
   
   // Return eqdsk struct

--- a/src/aegis_lib/EquilData.h
+++ b/src/aegis_lib/EquilData.h
@@ -205,7 +205,6 @@ class EquilData : public AegisBase
   alglib::spline1dinterpolant fSpline; // 1d spline interpolant for f(psi) or I(psi) toroidal component
 
   private:
-  int rank, nprocs;
 
   bool debug = false;
   bool drawEquRZ = false;

--- a/src/aegis_lib/EquilData.h
+++ b/src/aegis_lib/EquilData.h
@@ -81,7 +81,7 @@ class EquilData : public AegisBase
 
   public:
 
-  void setup(const std::shared_ptr<InputJSON> &inputs);
+  void setup(const std::shared_ptr<JsonHandler> &inputs);
 
   
   // Return eqdsk struct

--- a/src/aegis_lib/EquilData.h
+++ b/src/aegis_lib/EquilData.h
@@ -80,8 +80,14 @@ class EquilData : public AegisBase
 
 
   public:
+  EquilData(const std::shared_ptr<JsonHandler> &configFile);
+  EquilData();
 
-  void setup(const std::shared_ptr<JsonHandler> &inputs);
+  // read required parameters from config file
+  void read_required_params(json &EquilDataParams);
+  
+  // read optional parameters from config file
+  void read_optional_params(JsonHandler &EquilParams);
 
   
   // Return eqdsk struct

--- a/src/aegis_lib/Inputs.cpp
+++ b/src/aegis_lib/Inputs.cpp
@@ -8,17 +8,25 @@
 #include <mpi.h>
 #include <sstream>
 
-InputJSON::InputJSON() = default;
+JsonHandler::JsonHandler() = default;
 
-InputJSON::InputJSON(std::string filename)
+JsonHandler::JsonHandler(std::string filename)
 {
   filepath = filename;
 
-  data = read_json();
+  read_json();
 }
 
+JsonHandler::JsonHandler(json existingJSON) { jsonData = existingJSON; }
+
 json
-InputJSON::read_json()
+JsonHandler::data()
+{
+  return jsonData;
+}
+
+void
+JsonHandler::read_json()
 {
   int rank;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -29,8 +37,8 @@ InputJSON::read_json()
     {
       std::cout << "Settings found in JSON file '" << filepath << "'" << std::endl;
     }
-    json data = json::parse(file);
-    return data;
+    jsonData = json::parse(file);
+    return;
   }
   else
   {

--- a/src/aegis_lib/Inputs.h
+++ b/src/aegis_lib/Inputs.h
@@ -30,19 +30,26 @@ public:
   json data();
   void read_json();
 
-  template <class T> std::optional<T> get_optional(std::string paramName)  
+  template <class T> [[nodiscard]] T get_required(std::string paramName)  
+  { 
+    if(!jsonData.contains(paramName)) 
+      {
+        std::cerr << "Check config file - missing required parameter: {" << paramName << "} \n \n";
+        error_abort_mpi();
+      }
+    return jsonData[paramName];
+  }
+
+  template <class T> [[nodiscard]] std::optional<T> get_optional(std::string paramName)  
   {
-    if (jsonData.contains(paramName))
-    {
-      return (jsonData[paramName]);
-    }
-    else 
+    if (!jsonData.contains(paramName))
     {
       std::stringstream ss;
       ss << "Default value used for parameter " << paramName;
       log_string(LogLevel::INFO, ss.str());
       return std::nullopt;
-    }  
+    }
+    return (jsonData[paramName]);
   }
   
 private:

--- a/src/aegis_lib/Inputs.h
+++ b/src/aegis_lib/Inputs.h
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <any>
 #include <nlohmann/json.hpp>
+#include <variant>
 
 /**
  * Class for storing input settings from JSON file
@@ -18,16 +19,31 @@
 
 using json = nlohmann::json;
 
-class InputJSON
+class JsonHandler
 {
   public:
-  InputJSON();
-  InputJSON(std::string filename);
-  json read_json();
-  json data;
+  JsonHandler();
+  JsonHandler(std::string filename);
+  JsonHandler(json existingJSON);
+  json data();
+  void read_json();
+
+  template <class T> std::optional<T> get(std::string parameter)
+  {
+    if (jsonData.contains(parameter))
+    {
+      return (jsonData[parameter]);
+    }
+    else 
+    {
+      return std::nullopt;
+    }
+  }
+  
 
   private:
   std::string filepath; 
+  json jsonData;
 
 };
 

--- a/src/aegis_lib/Inputs.h
+++ b/src/aegis_lib/Inputs.h
@@ -11,6 +11,7 @@
 #include <any>
 #include <nlohmann/json.hpp>
 #include <variant>
+#include <AegisBase.h>
 
 /**
  * Class for storing input settings from JSON file
@@ -19,29 +20,32 @@
 
 using json = nlohmann::json;
 
-class JsonHandler
+class JsonHandler : public AegisBase
 {
-  public:
+public:
+
   JsonHandler();
   JsonHandler(std::string filename);
   JsonHandler(json existingJSON);
   json data();
   void read_json();
 
-  template <class T> std::optional<T> get(std::string parameter)
+  template <class T> std::optional<T> get_optional(std::string paramName)  
   {
-    if (jsonData.contains(parameter))
+    if (jsonData.contains(paramName))
     {
-      return (jsonData[parameter]);
+      return (jsonData[paramName]);
     }
     else 
     {
+      std::stringstream ss;
+      ss << "Default value used for parameter " << paramName;
+      log_string(LogLevel::INFO, ss.str());
       return std::nullopt;
-    }
+    }  
   }
   
-
-  private:
+private:
   std::string filepath; 
   json jsonData;
 

--- a/src/aegis_lib/Particle.cpp
+++ b/src/aegis_lib/Particle.cpp
@@ -11,6 +11,11 @@
 
 ParticleBase::ParticleBase(coordinateSystem coordSys) { coordSystem = coordSys; }
 
+void
+ParticleBase::set_facet_history(moab::DagMC::RayHistory history)
+{
+  facetHistory = history;
+}
 // set current particle posXYZition
 void
 ParticleBase::set_pos(std::vector<double> newPosition)
@@ -23,38 +28,6 @@ ParticleBase::set_pos(std::vector<double> newPosition)
   }
   previousPos = posXYZ;
   posXYZ = newPosition; // set the new posXYZition
-}
-
-// overload set_pos() for C-style array
-void
-ParticleBase::set_pos(double newPosition[])
-{
-  std::vector<double> tempVector(3);
-  for (int i = 0; i < 3; i++)
-  {
-    tempVector[i] = newPosition[i];
-  }
-
-  if (posXYZ.empty())
-  {
-    launchPos = tempVector;
-  }
-  posXYZ = tempVector; // set the new posXYZition
-}
-
-// Check if particle is currently in magnetic field
-void
-ParticleBase::check_if_in_bfield(const std::shared_ptr<EquilData> & equilibrium)
-{
-  std::vector<double> currentBfield = equilibrium->b_field(posXYZ, "cart");
-  if (currentBfield.empty())
-  {
-    outOfBounds = true;
-  }
-  else
-  {
-    outOfBounds = false;
-  }
 }
 
 // return STL vector of current particle posXYZition
@@ -82,12 +55,6 @@ ParticleBase::get_psi(const std::shared_ptr<EquilData> & equilibrium)
 void
 ParticleBase::set_dir(const std::shared_ptr<EquilData> & equilibrium)
 {
-  check_if_in_bfield(equilibrium);
-  if (outOfBounds)
-  {
-    return;
-  } // exit function early if out of bounds
-
   double norm = 0;              // normalisation constant for magnetic field
   std::vector<double> normB(3); // normalised magnetic field
   std::vector<double> polarPos =

--- a/src/aegis_lib/Particle.h
+++ b/src/aegis_lib/Particle.h
@@ -29,6 +29,8 @@ class ParticleBase : public AegisBase
   double thresholdDistanceThreshold = 0.0;
   double euclidDistTravelled = 0.0;
   bool thresholdDistanceCrossed = false;
+  moab::DagMC::RayHistory facetHistory;
+  
   coordinateSystem coordSystem = coordinateSystem::CARTESIAN;
   //DagMC::RayHistory history; // stores entity handles of surfaces crossed and facets hit
 
@@ -46,13 +48,12 @@ class ParticleBase : public AegisBase
 
 
 
-  ParticleBase(coordinateSystem coordSys);
+
+  ParticleBase(coordinateSystem coordSys);  
+  void set_facet_history(moab::DagMC::RayHistory history);
 
   // set new particle position
   void set_pos(std::vector<double> newPosition); 
-  
-  // overload for C-style array
-  void set_pos(double newPosition[]); 
 
   // return STL vector of the current position
   std::vector<double> get_pos();
@@ -65,7 +66,6 @@ class ParticleBase : public AegisBase
 
   // return STL vector of unit direction
   std::vector<double> get_dir(); 
-  void check_if_in_bfield(const std::shared_ptr<EquilData> &Equdata); // check if in magnetic field
   void align_dir_to_surf(double Bn); // align particle dir to surface normal
   void update_vectors(double distanceTravelled); // update position  
   void update_vectors(double distanceTravelled, const std::shared_ptr<EquilData> &EquData); // overload to update dir as well

--- a/src/aegis_lib/Particle.h
+++ b/src/aegis_lib/Particle.h
@@ -25,7 +25,7 @@ class ParticleBase : public AegisBase
   double power = 0.0; // power associated with particle
   double lengthTravelled = 0.0; // total length travelled by particle
   bool directionUp = false; 
-  std::vector<double> previousPos;
+  std::vector<double> previousPos; // previous position in particle history
   double thresholdDistanceThreshold = 0.0;
   double euclidDistTravelled = 0.0;
   bool thresholdDistanceCrossed = false;
@@ -38,18 +38,16 @@ class ParticleBase : public AegisBase
   std::vector<double> Bfield; // magnetic field at current pos
   std::vector<double> dir; // unit direction vector of particle at current position
   std::vector<double> BfieldXYZ; // cartesian mangetic field
-  std::vector<double> posXYZ; // current position of particle in xyz
-  std::vector<double> posPolar;
-  std::vector<double> posFlux; 
   std::vector<double> launchPos; // initial starting position of particle on triangle
   int atMidplane; // 0 == Not at midplane; 1 == At Inner-Midplane; 2 == At Outer-Midplane  
   bool outOfBounds = false;
   bool thresholdDistanceSet = false;
+  std::vector<double> pos; // current positiion
 
 
 
 
-  ParticleBase(coordinateSystem coordSys);  
+  ParticleBase(coordinateSystem coordSys, std::vector<double> startingPosition);  
   void set_facet_history(moab::DagMC::RayHistory history);
 
   // set new particle position
@@ -57,6 +55,7 @@ class ParticleBase : public AegisBase
 
   // return STL vector of the current position
   std::vector<double> get_pos();
+  std::vector<double> get_xyz_pos();
 
   // get psi value at current pos
   double get_psi(const std::shared_ptr<EquilData> &EquData); 

--- a/src/aegis_lib/ParticleSimulation.cpp
+++ b/src/aegis_lib/ParticleSimulation.cpp
@@ -358,17 +358,7 @@ ParticleSimulation::read_params(const std::shared_ptr<JsonHandler> & configFile)
     auto aegisParamsData = configFile->data()["aegis_params"];
     JsonHandler aegisParams(aegisParamsData);
 
-    try
-    {
-      dagmcInputFile = aegisParamsData["DAGMC"];
-    }
-    catch (const std::exception & e)
-    {
-      std::cerr << e.what() << '\n';
-      std::cerr << "Check config file. Missing required parameter: 'eqdsk' \n \n";
-      std::cerr << "Terminating program... \n";
-      MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
-    }
+    dagmcInputFile = aegisParams.get_required<std::string>("DAGMC");
 
     trackStepSize = aegisParams.get_optional<double>("step_size").value_or(trackStepSize);
 

--- a/src/aegis_lib/ParticleSimulation.cpp
+++ b/src/aegis_lib/ParticleSimulation.cpp
@@ -2,19 +2,64 @@
 #include <mpi.h>
 
 // setup AEGIS simulation
-ParticleSimulation::ParticleSimulation(std::shared_ptr<InputJSON> configFile,
+ParticleSimulation::ParticleSimulation(std::shared_ptr<JsonHandler> configFile,
                                        std::shared_ptr<EquilData> equil)
 {
   set_mpi_params();
 
-  JSONsettings = configFile;
-
-  read_params(JSONsettings);
+  read_params(configFile);
   equilibrium = equil;
   DAG = std::make_unique<moab::DagMC>();
-  vtkInterface = std::make_unique<VtkInterface>(JSONsettings);
+  vtkInterface = std::make_unique<VtkInterface>(configFile);
 
   init_geometry();
+}
+
+void
+ParticleSimulation::test_cyl_ray_fire(std::unique_ptr<ParticleBase> & particle)
+{
+
+  std::ofstream coordinateTest("coords.txt");
+  std::ofstream coordinateTest2("coords2.txt");
+  std::vector<double> cartPos = particle->pos;
+  std::vector<double> bfieldXYZ = particle->dir;
+  std::vector<double> polPos = CoordTransform::cart_to_polar(cartPos);
+  std::vector<double> bFieldRZ = equilibrium->b_field(cartPos, "");
+
+  std::vector<double> outputPosition1(3), outputPosition2(3);
+  ParticleBase cartParticle(coordinateSystem::CARTESIAN, cartPos);
+  cartParticle.set_pos(cartPos);
+  cartParticle.set_dir(equilibrium);
+
+  ParticleBase polarParticle(coordinateSystem::POLAR, polPos);
+  polarParticle.set_pos(polPos);
+  polarParticle.set_dir(equilibrium);
+
+  double cartStepSize = 0.01;
+  double polarStepSize = 0.1;
+  double distanceToSurf;
+  moab::EntityHandle eh;
+  moab::DagMC::RayHistory history;
+
+  for (int i = 0; i < 1000; ++i)
+  {
+    DAG->ray_fire(implComplementVol, cartParticle.pos.data(), cartParticle.dir.data(), eh,
+                  distanceToSurf, &history, cartStepSize, 1);
+    cartParticle.update_vectors(cartStepSize);
+    cartParticle.set_dir(equilibrium);
+    coordinateTest << cartParticle.pos[0] << " " << cartParticle.pos[1] << " "
+                   << cartParticle.pos[2] << std::endl;
+  }
+
+  for (int i = 0; i < 100; ++i)
+  {
+    DAG->ray_fire(implComplementVol, polarParticle.pos.data(), polarParticle.dir.data(), eh,
+                  distanceToSurf, &history, cartStepSize, 1);
+    polarParticle.update_vectors(polarStepSize);
+    polarParticle.set_dir(equilibrium);
+    cartPos = CoordTransform::polar_to_cart(polarParticle.pos);
+    coordinateTest2 << cartPos[0] << " " << cartPos[1] << " " << cartPos[2] << std::endl;
+  }
 }
 
 // Call different execute functions depending on which execute type selected
@@ -60,6 +105,7 @@ ParticleSimulation::Execute()
   {
     log_string(LogLevel::FATAL, "No suitable execution type ('serial', 'mpi', 'mpi_padded', "
                                 "'mpi_dynamic') provided exiting...");
+    MPI_Abort(MPI_COMM_WORLD, 1);
     std::exit(1);
   }
 }
@@ -76,7 +122,7 @@ ParticleSimulation::Execute_dynamic_mpi()
 
   const int noMoreWork = -1;
 
-  std::vector<double> handlerQVals(num_facets());
+  std::vector<double> handlerQVals(target_num_facets());
   // int counter = 0;
   setup_sources();
 
@@ -148,17 +194,17 @@ ParticleSimulation::handler(std::vector<double> & handlerQVals)
   int noMoreWork = -1;
   int counter = 0;
 
-  std::vector<double> workerQVals(dynamicTaskSize);
+  std::vector<double> workerQVals(dynamicBatchSize);
   std::cout << "Dynamic task scheduling with " << (nprocs - 1) << " processes, each handling "
-            << dynamicTaskSize << " facets" << std::endl;
+            << dynamicBatchSize << " facets" << std::endl;
   int particlesHandled = 0;
   int batchesComplete = 0;
-  int totalBatches = num_facets() / dynamicTaskSize;
+  int totalBatches = target_num_facets() / dynamicBatchSize;
 
   for (int procID = 1; procID < nprocs; procID++)
   { // Send the initial indexes for each process statically
     MPI_Send(&particlesHandled, 1, MPI_INT, procID, procID, MPI_COMM_WORLD);
-    particlesHandled += dynamicTaskSize;
+    particlesHandled += dynamicBatchSize;
     batchesComplete += 1;
   }
 
@@ -181,7 +227,7 @@ ParticleSimulation::handler(std::vector<double> & handlerQVals)
       MPI_Recv(&workerStartIndex, 1, MPI_INT, MPI_ANY_SOURCE, mpiIndexTag, MPI_COMM_WORLD, &status);
       // printf("Time taken to recieve next data = %f \n", MPI_Wtime());
 
-      particlesHandled += dynamicTaskSize;
+      particlesHandled += dynamicBatchSize;
       batchesComplete += 1;
       // progress indicator
 
@@ -236,17 +282,21 @@ ParticleSimulation::worker()
   int counterDeposit = 0;
   int index = 0;
 
-  // std::ofstream file;
-  // std::stringstream fileName;
-  // fileName << "rank" << rank << ".txt";
-  // file.open(fileName.str());
+  if (workerDebug)
+  {
+    // std::ofstream workerOutputFile;
+    // std::stringstream fileName;
+    // fileName << "rank" << rank << ".txt";
+    // workerOutputFile.open(fileName.str());
+    printf("Testing");
+  }
 
   std::vector<double> workerQVals;
   int startIndex = 0;
   MPI_Recv(&startIndex, 1, MPI_INT, 0, rank, MPI_COMM_WORLD, &status);
 
   int start = startIndex;
-  int end = start + dynamicTaskSize;
+  int end = start + dynamicBatchSize;
 
   workerQVals = loop_over_facets(start, end); // process initial facets
   // file << "Loop over [" << start << ":" << end << "] facets: \n";
@@ -266,13 +316,13 @@ ParticleSimulation::worker()
     MPI_Send(&rank, 1, MPI_INT, 0, 1, MPI_COMM_WORLD);
     MPI_Recv(&startIndex, 1, MPI_INT, 0, 1, MPI_COMM_WORLD, &status);
 
-    if (startIndex + dynamicTaskSize > num_facets())
+    if (startIndex + dynamicBatchSize > target_num_facets())
     {
-      dynamicTaskSize = num_facets() - startIndex;
+      dynamicBatchSize = target_num_facets() - startIndex;
     }
 
     start = startIndex;
-    end = start + dynamicTaskSize;
+    end = start + dynamicBatchSize;
 
     if (startIndex != noMoreWork)
     { // processing the next set of available work
@@ -300,25 +350,32 @@ ParticleSimulation::worker()
 
 // Read parameters from aegis_settings.json config file
 void
-ParticleSimulation::read_params(const std::shared_ptr<InputJSON> & inputs)
+ParticleSimulation::read_params(const std::shared_ptr<JsonHandler> & configFile)
 {
 
-  if (inputs->data.contains("aegis_params"))
+  if (configFile->data().contains("aegis_params"))
   {
-    json aegisParams = inputs->data["aegis_params"];
+    json aegisParams = configFile->data()["aegis_params"];
 
     dagmcInputFile = aegisParams["DAGMC"];
     trackStepSize = aegisParams["step_size"];
     maxTrackSteps = aegisParams["max_steps"];
     particleLaunchPos = aegisParams["launch_pos"];
+
     noMidplaneTermination = aegisParams["force_no_deposition"];
-    coordInputStr = aegisParams["coordinate_system"];
+
+    coordinateConfig = aegisParams["coordinate_system"];
     exeType = aegisParams["execution_type"];
 
-    if (aegisParams.contains("task_farm_params"))
+    if (aegisParams.contains("dynamic_batch_params"))
     {
-      dynamicTaskSize = aegisParams["task_farm_params"]["dynamic_task_size"];
-      workerProfiling = aegisParams["task_farm_params"]["worker_profiling_enabled"];
+      JsonHandler dynamicBatchParams(configFile->data()["aegis_params"]["dynamic_batch_params"]);
+      dynamicBatchSize = aegisParams["dynamic_batch_params"]["batch_size"];
+      workerProfiling = aegisParams["dynamic_batch_params"]["worker_profiling"];
+      // dynamicBatchSize = dynamicBatchParams.get<int>("batch_size").value_or(dynamicBatchSize);
+      // workerProfiling =
+      // dynamicBatchParams.get<bool>("worker_profiling").value_or(workerProfiling); workerDebug =
+      // dynamicBatchParams["worker_debug"];
     }
 
     if (aegisParams.contains("target_surfs"))
@@ -339,18 +396,18 @@ ParticleSimulation::read_params(const std::shared_ptr<InputJSON> & inputs)
 void
 ParticleSimulation::select_coordinate_system()
 {
-  string_to_lowercase(coordInputStr);
-  if (coordInputStr == "cart" || coordInputStr == "cartesian" || coordInputStr == "xyz")
+  string_to_lowercase(coordinateConfig);
+  if (coordinateConfig == "cart" || coordinateConfig == "cartesian" || coordinateConfig == "xyz")
   {
     coordSys = coordinateSystem::CARTESIAN;
     log_string(LogLevel::WARNING, "Tracking in CARTESIAN coordinates...");
   }
-  else if (coordInputStr == "pol" || coordInputStr == "polar" || coordInputStr == "rz")
+  else if (coordinateConfig == "pol" || coordinateConfig == "polar" || coordinateConfig == "rz")
   {
     coordSys = coordinateSystem::POLAR;
     log_string(LogLevel::WARNING, "Tracking in POLAR coordinates...");
   }
-  else if (coordInputStr == "flux" || coordInputStr == "psi")
+  else if (coordinateConfig == "flux" || coordinateConfig == "psi")
   {
     coordSys = coordinateSystem::FLUX;
     log_string(LogLevel::WARNING, "Tracking in FLUX coordinates...");
@@ -446,7 +503,7 @@ ParticleSimulation::loop_over_facets(int startFacet, int endFacet)
     }
 
     // DagMC::RayHistory history;
-    auto particle = std::make_unique<ParticleBase>(coordSys);
+    auto particle = std::make_unique<ParticleBase>(coordSys, tri.launch_pos());
 
     try
     {
@@ -459,8 +516,6 @@ ParticleSimulation::loop_over_facets(int startFacet, int endFacet)
       continue;
     }
     integrator->set_launch_position(tri.entity_handle(), tri.launch_pos());
-    trackLength = trackStepSize;
-
     terminationState particleState = loop_over_particle_track(tri, particle);
 
     // if particle not depositing set heatflux to 0.0
@@ -527,18 +582,18 @@ ParticleSimulation::loop_over_particle_track(TriangleSource & tri,
   particle->set_pos(tri.launch_pos());
   particle->set_dir(equilibrium);
   particle->align_dir_to_surf(tri.BdotN());
-  trackLength = trackStepSize;
-  particle->update_vectors(trackStepSize, equilibrium);
+  // test_cyl_ray_fire(particle);
 
   vtkInterface->init_new_vtkPoints();
-  vtkInterface->insert_next_point_in_track(particle->launchPos);
+  vtkInterface->insert_next_point_in_track(particle->get_xyz_pos());
   moab::DagMC::RayHistory history;
+
   for (int step = 0; step < maxTrackSteps; ++step)
   {
     trackLength += trackStepSize;
     iterationCounter++;
 
-    DAG->ray_fire(implComplementVol, particle->posXYZ.data(), particle->dir.data(), nextSurf,
+    DAG->ray_fire(implComplementVol, particle->pos.data(), particle->dir.data(), nextSurf,
                   nextSurfDist, &history, trackStepSize, rayOrientation);
     numberOfRayFireCalls++;
 
@@ -553,11 +608,11 @@ ParticleSimulation::loop_over_particle_track(TriangleSource & tri,
       particle->update_vectors(trackStepSize); // update position by stepsize
     }
 
-    vtkInterface->insert_next_point_in_track(particle->posXYZ);
+    vtkInterface->insert_next_point_in_track(particle->get_xyz_pos());
 
     try
     {
-      equilibrium->check_if_in_bfield(particle->posXYZ);
+      equilibrium->check_if_in_bfield(particle->pos);
     }
     catch (std::runtime_error & e)
     {
@@ -574,16 +629,12 @@ ParticleSimulation::loop_over_particle_track(TriangleSource & tri,
       terminate_particle_depositing(tri);
       return terminationState::DEPOSITING;
     }
-
-    if (step == (maxTrackSteps - 1))
-    {
-      terminate_particle_maxlength(tri);
-      return terminationState::MAXLENGTH;
-    }
   }
 
   particle->set_facet_history(history);
-  return terminationState::LOST; // default return lost particle
+  // max length of particle track reached
+  terminate_particle_maxlength(tri);
+  return terminationState::MAXLENGTH;
 }
 
 // terminate particle after reaching midplane
@@ -716,15 +767,15 @@ ParticleSimulation::select_target_surface()
     LOG_WARNING << "Total Number of Triangles rays launched from = " << numTargetFacets;
   }
 
-  numFacets = targetFacets.size();
+  targetNumFacets = targetFacets.size();
   return targetFacets;
 }
 
 // return total number of facets in target surface(s) of interest
 int
-ParticleSimulation::num_facets()
+ParticleSimulation::target_num_facets()
 {
-  return numFacets;
+  return targetNumFacets;
 }
 
 // print stats for the entire run
@@ -751,7 +802,8 @@ ParticleSimulation::print_particle_stats(std::array<int, 5> particleStats)
     LOG_WARNING << "Number of particles terminated upon reaching max tracking length = "
                 << particleStats[3];
     LOG_WARNING << "Number of padded null particles = " << particleStats[4];
-    LOG_WARNING << "Number of particles not accounted for = " << (num_facets() - particlesCounted);
+    LOG_WARNING << "Number of particles not accounted for = "
+                << (target_num_facets() - particlesCounted);
   }
   // std::cout << "Number of Ray fire calls = " << numberOfRayFireCalls <<
   // std::endl;
@@ -810,9 +862,9 @@ ParticleSimulation::Execute_serial()
     std::exit(EXIT_FAILURE);
   }
 
-  std::vector<double> psiStart(num_facets());
-  std::vector<double> bnList(num_facets());
-  std::vector<std::vector<double>> normalList(num_facets());
+  std::vector<double> psiStart(target_num_facets());
+  std::vector<double> bnList(target_num_facets());
+  std::vector<std::vector<double>> normalList(target_num_facets());
   for (int i = 0; i < listOfTriangles.size(); ++i)
   {
     psiStart[i] = listOfTriangles[i].get_psi();
@@ -845,12 +897,12 @@ ParticleSimulation::Execute_padded_mpi()
   targetFacets = select_target_surface();
   integrator = std::make_unique<SurfaceIntegrator>(targetFacets);
 
-  int totalFacets = num_facets();
+  int totalFacets = target_num_facets();
   int remainder = totalFacets % nprocs;
   int nPadded = 0;
   if (remainder != 0)
   {
-    int paddedTotalFacets = num_facets() + (nprocs - remainder);
+    int paddedTotalFacets = target_num_facets() + (nprocs - remainder);
     nPadded = paddedTotalFacets - totalFacets;
     totalFacets = paddedTotalFacets;
   }
@@ -879,7 +931,7 @@ ParticleSimulation::Execute_padded_mpi()
     totalParticleStats = integrator->particle_stats();
     MPI_Gather(qvalues.data(), qvalues.size(), MPI_DOUBLE, rootQvalues.data(), qvalues.size(),
                MPI_DOUBLE, rootRank, MPI_COMM_WORLD);
-    if (rootQvalues.size() > num_facets())
+    if (rootQvalues.size() > target_num_facets())
     {
       rootQvalues.resize(rootQvalues.size() - nPadded);
     }
@@ -911,7 +963,7 @@ ParticleSimulation::Execute_mpi()
   targetFacets = select_target_surface();
   integrator = std::make_unique<SurfaceIntegrator>(targetFacets);
 
-  int totalFacets = num_facets();
+  int totalFacets = target_num_facets();
   int nFacetsPerProc = totalFacets / nprocs;
   int remainder = totalFacets % nprocs;
 
@@ -951,7 +1003,7 @@ ParticleSimulation::Execute_mpi()
   setup_sources();
 
   qvalues = loop_over_facets(startFacet, endFacet); // perform main loop
-  endTime = MPI_Wtime();
+  double endTime = MPI_Wtime();
 
   std::array<int, 5> particleStats = integrator->particle_stats();
   std::array<int, 5> totalParticleStats;
@@ -991,7 +1043,6 @@ ParticleSimulation::Execute_mpi()
   endTime = MPI_Wtime();
 }
 
-// get surfaces attributed to the aegis_target group set in cubit
 void
 ParticleSimulation::implicit_complement_testing()
 {
@@ -1021,9 +1072,9 @@ ParticleSimulation::implicit_complement_testing()
   {
     implicitComplCoordsxyz << vertexCoords[i] << " " << vertexCoords[i + 1] << " "
                            << vertexCoords[i + 2] << std::endl;
-    temp1 = CoordTransform::cart_to_polar(vertexCoords[i], vertexCoords[i + 1], vertexCoords[i + 2],
-                                          "forwards");
-    temp2 = CoordTransform::polar_to_flux(temp1, "forwards", equilibrium);
+    temp1 =
+        CoordTransform::cart_to_polar(vertexCoords[i], vertexCoords[i + 1], vertexCoords[i + 2]);
+    temp2 = CoordTransform::polar_to_flux(temp1, equilibrium);
     vertexCoordsFlux[i] = temp2[0];
     vertexCoordsFlux[i + 1] = temp2[1];
     vertexCoordsFlux[i + 2] = temp2[2];
@@ -1083,6 +1134,7 @@ ParticleSimulation::attach_mesh_attribute(const std::string & tagName, moab::Ran
 void
 ParticleSimulation::write_out_mesh(meshWriteOptions option, moab::Range rangeofEntities)
 {
+  // mesh_coord_transform(coordinateSystem::CARTESIAN);
   // get target meshset for aegis_target outputs
   DAG->remove_graveyard();
   EntityHandle targetMeshset;
@@ -1147,7 +1199,7 @@ ParticleSimulation::mesh_coord_transform(coordinateSystem coordSys)
       for (int i = 0; i < nodeCoords.size(); i += 3)
       {
         temp = {nodeCoords[i], nodeCoords[i + 1], nodeCoords[i + 2]};
-        temp = CoordTransform::cart_to_polar(temp, "backwards");
+        temp = CoordTransform::polar_to_cart(temp);
         DAG->moab_instance()->set_coords(&nodesList[counter], 1, temp.data());
         counter += 1;
       }
@@ -1157,7 +1209,7 @@ ParticleSimulation::mesh_coord_transform(coordinateSystem coordSys)
       for (int i = 0; i < nodeCoords.size(); i += 3)
       {
         temp = {nodeCoords[i], nodeCoords[i + 1], nodeCoords[i + 2]};
-        temp = CoordTransform::cart_to_polar(temp, "forwards");
+        temp = CoordTransform::cart_to_polar(temp);
         DAG->moab_instance()->set_coords(&nodesList[counter], 1, temp.data());
         counter += 1;
       }
@@ -1167,8 +1219,8 @@ ParticleSimulation::mesh_coord_transform(coordinateSystem coordSys)
       // for (int i=0; i<nodeCoords.size(); i+=3)
       // {
       //   temp = {nodeCoords[i], nodeCoords[i+1], nodeCoords[i+2]};
-      //   temp = CoordTransform::cart_to_polar(temp, "forwards");
-      //   temp = CoordTransform::polar_to_flux(temp, "forwards", equilibrium);
+      //   temp = CoordTransform::cart_to_polar(temp);
+      //   temp = CoordTransform::polar_to_flux(temp, equilibrium);
       //   DAG->moab_instance()->set_coords(&nodesList[counter], 1, temp.data());
       //   counter +=1;
       // }

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -105,15 +105,15 @@ class ParticleSimulation : public AegisBase
   void polar_track();
   void flux_track();
   
-  terminationState loop_over_particle_track(TriangleSource&tri, std::unique_ptr<ParticleBase> &particle, DagMC::RayHistory &history); // loop over individual particle tracks
+  terminationState loop_over_particle_track(TriangleSource&tri, std::unique_ptr<ParticleBase> &particle); // loop over individual particle tracks
   void terminate_particle_depositing(TriangleSource&tri); // end particle track
-  void terminate_particle_shadow(TriangleSource&tri, DagMC::RayHistory &history); // end particle track
+  void terminate_particle_shadow(TriangleSource&tri); // end particle track
   void terminate_particle_lost(TriangleSource&tri); // end particle track
   void terminate_particle_maxlength(TriangleSource&tri); // end particle track
   
   
   
-  void ray_hit_on_launch(std::unique_ptr<ParticleBase> &particle, DagMC::RayHistory &history); // particle hit on initial launch from surface
+  void ray_hit_on_launch(std::unique_ptr<ParticleBase> &particle); // particle hit on initial launch from surface
   void print_particle_stats(std::array<int, 5> particleStats); // print number of particles that reached each termination state
   void mpi_particle_stats(); // get inidividual particle stats for each process
   void read_params(const std::shared_ptr<InputJSON> &inputs); // read parameters from aegis_settings.json

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -78,16 +78,15 @@ enum class ExecuteOptions
 class ParticleSimulation : public AegisBase
 {
   public:
-  ParticleSimulation(std::shared_ptr<InputJSON> configFile, std::shared_ptr<EquilData> equil);
+  ParticleSimulation(std::shared_ptr<JsonHandler> configFile, std::shared_ptr<EquilData> equil);
   void Execute(); // switch between runs
   void Execute_serial(); // serial
   void Execute_mpi(); // MPI_Gatherv
   void Execute_dynamic_mpi(); // dynamic load balancing
   void Execute_padded_mpi(); // padded MPI_Gather
   void init_geometry();
-  int num_facets();
   std::vector<std::pair<double,double>> psiQ_values; // for l2 norm test
-
+  int target_num_facets();
 
   protected:
 
@@ -110,13 +109,13 @@ class ParticleSimulation : public AegisBase
   void terminate_particle_shadow(TriangleSource&tri); // end particle track
   void terminate_particle_lost(TriangleSource&tri); // end particle track
   void terminate_particle_maxlength(TriangleSource&tri); // end particle track
-  
+  void test_cyl_ray_fire(std::unique_ptr<ParticleBase> &particle);  
   
   
   void ray_hit_on_launch(std::unique_ptr<ParticleBase> &particle); // particle hit on initial launch from surface
   void print_particle_stats(std::array<int, 5> particleStats); // print number of particles that reached each termination state
   void mpi_particle_stats(); // get inidividual particle stats for each process
-  void read_params(const std::shared_ptr<InputJSON> &inputs); // read parameters from aegis_settings.json
+  void read_params(const std::shared_ptr<JsonHandler> &inputs); // read parameters from aegis_settings.json
   void attach_mesh_attribute(const std::string &tagName, moab::Range &entities, std::vector<double> &dataToAttach);
   void attach_mesh_attribute(const std::string &tagName, moab::Range &entities, std::vector<std::vector<double>> &dataToAttach);
   
@@ -124,42 +123,34 @@ class ParticleSimulation : public AegisBase
   void mesh_coord_transform(coordinateSystem coordSys);
   void select_coordinate_system();
   
-  std::string exeType;
-  int nFacets;
-  
-  std::vector<TriangleSource> listOfTriangles;
-  unsigned int totalNumberOfFacets = 0;
-
-  std::string settingsFileName;
-  std::shared_ptr<InputJSON> JSONsettings; 
-  std::string dagmcInputFile;
-  std::string vtkInputFile;
+  // Simulation config parameters
+  std::string exeType = "dynamic";
+  std::string dagmcInputFile; // no defaults because 
   std::string eqdskInputFile;
   double powerSOL = 0.0;
   double lambdaQ = 0.0; 
-  double trackStepSize;
+  double trackStepSize = 0.001;
   int maxTrackSteps = 0;
-  std::string particleLaunchPos;
-  double userROutrBdry;
-  std::string drawParticleTracks;
-  int dynamicTaskSize;
-  std::string coordInputStr;
+  std::string particleLaunchPos = "fixed";
+  double userROutrBdry = 0.0;
+  int dynamicBatchSize = 16;
+  std::string coordinateConfig = "cart";
   bool workerProfiling = false;
+  bool workerDebug = false;
   coordinateSystem coordSys = coordinateSystem::CARTESIAN; // default cartesian 
-
-  double rmove = 0.0;
-  double zmove = 0.0;
-  double fscale = 1.0;
-  double psiref = 0.0;
   bool noMidplaneTermination = false;
+
+  std::vector<TriangleSource> listOfTriangles;
+  int totalNumberOfFacets = 0;
+
   std::vector<int> vectorOfTargetSurfs;
   unsigned int numberOfRayFireCalls = 0;
   unsigned int numberOfClosestLocCalls = 0;
   unsigned int iterationCounter=0;
 
+
+  // DAGMC variables
   std::unique_ptr<moab::DagMC> DAG;
-  std::unique_ptr<moab::DagMC> polarDAG;
-  std::unique_ptr<moab::DagMC> fluxDAG;
   moab::Range surfsList; // list of moab::EntityHandle of surfaces in mesh
   moab::Range volsList; // list of moab::EntityHandle of volumes in mesh
   moab::Range facetsList; // list of moab::EntityHandle of facets in mesh
@@ -167,7 +158,7 @@ class ParticleSimulation : public AegisBase
   std::vector<EntityHandle> nodesList; // list of moab::EntityHandle of nodes in mesh
   std::vector<double> nodeCoords; // 1D flattended list of node XYZ coordinates 
   std::vector<double> nodeCoordsPol; // 1D flattended list of node polar coordinates
-  int numFacets = 0;
+  int targetNumFacets = 0;
   int numNodes = 0;
   moab::EntityHandle prevSurf;
   moab::EntityHandle nextSurf;
@@ -176,17 +167,11 @@ class ParticleSimulation : public AegisBase
   moab::EntityHandle intersectedFacet;
   int rayOrientation = 1; // rays are fired along surface normals
   double trackLength = 0.0;
-  int facetCounter = 0;
 
-  std::vector<double> qValues;
-  std::vector<double> psiValues;
   double startTime;
-  double endTime;
   double facetsLoopTime;
 
   std::shared_ptr<EquilData> equilibrium;
-  bool plotBFieldRZ = false;
-  bool plotBFieldXYZ = false;
   
   std::unique_ptr<SurfaceIntegrator> integrator;
 

--- a/src/aegis_lib/Source.cpp
+++ b/src/aegis_lib/Source.cpp
@@ -100,8 +100,8 @@ Sources::set_heatflux_params(const std::shared_ptr<EquilData> & equilibrium,
   std::vector<double> bField;
   std::vector<double> bFieldXYZ;
 
-  polarPos = CoordTransform::cart_to_polar(launchPos, "forwards");
-  fluxPos = CoordTransform::polar_to_flux(polarPos, "forwards", equilibrium);
+  polarPos = CoordTransform::cart_to_polar(launchPos);
+  fluxPos = CoordTransform::polar_to_flux(polarPos, equilibrium);
 
   bField = equilibrium->b_field(polarPos, "forwards");
 

--- a/src/aegis_lib/VtkInterface.cpp
+++ b/src/aegis_lib/VtkInterface.cpp
@@ -1,13 +1,13 @@
 #include "VtkInterface.h"
 #include "SimpleLogger.h"
 
-VtkInterface::VtkInterface(const std::shared_ptr<InputJSON> & inputs)
+VtkInterface::VtkInterface(const std::shared_ptr<JsonHandler> & inputs)
 {
   json vtkNamelist;
 
-  if (inputs->data.contains("vtk_params"))
+  if (inputs->data().contains("vtk_params"))
   {
-    vtkNamelist = inputs->data["vtk_params"];
+    vtkNamelist = inputs->data()["vtk_params"];
     drawParticleTracks = vtkNamelist["draw_particle_tracks"];
   }
 

--- a/src/aegis_lib/VtkInterface.h
+++ b/src/aegis_lib/VtkInterface.h
@@ -25,7 +25,7 @@
 class VtkInterface : public AegisBase
 {
   public:
-  VtkInterface(const std::shared_ptr<InputJSON> &JSONsettings);
+  VtkInterface(const std::shared_ptr<JsonHandler> &JSONsettings);
   void init_Ptrack_root();
   void init_Ptrack_branch(std::string branchName);
   void init(); // initialise unstructured grid and particle tracks multiblock

--- a/test/data/aegis_settings.json
+++ b/test/data/aegis_settings.json
@@ -2,13 +2,17 @@
   "description": "inres1 test case to compare against SMARDDA",
   "aegis_params":{
       "DAGMC": "inres1_shad.h5m",
-      "step_size": 0.005,
+      "step_size": 0.01,
       "max_steps": 100000,
       "launch_pos": "fixed",
       "target_surfs": [1,2,3,4,5,6],
       "force_no_deposition": false,
-      "dynamic_task_size": 100,
-      "coordinate_system": "cart"
+      "coordinate_system": "cart",
+      "execution_type": "dynamic",
+      "task_farm_params":{
+          "dynamic_task_size": 16,
+          "worker_profiling_enabled": false        
+      } 
   },
   "equil_params":{
       "eqdsk": "EQ3.eqdsk",
@@ -23,7 +27,6 @@
       "print_debug_info": false
   },
   "vtk_params":{
-      "VTK": "target_facets.stl",
       "draw_particle_tracks": false
   }
  }

--- a/test/regression/inres1_regression.cpp
+++ b/test/regression/inres1_regression.cpp
@@ -81,9 +81,8 @@ double dot_product(std::vector<double> vector_a, std::vector<double> vector_b);
   std::string configFilename = "aegis_settings.json";
   auto configFile = std::make_shared<JsonHandler>(configFilename);
 
-  auto equilibrium = std::make_shared<EquilData>();
-  equilibrium->setup(configFile);
-  equilibrium->move();
+  auto equilibrium = std::make_shared<EquilData>(configFile);
+   equilibrium->move();
   equilibrium->psiref_override();
   equilibrium->init_interp_splines();
   equilibrium->centre(1);

--- a/test/regression/inres1_regression.cpp
+++ b/test/regression/inres1_regression.cpp
@@ -79,7 +79,7 @@ double dot_product(std::vector<double> vector_a, std::vector<double> vector_b);
   }
 //-------------- RUN AEGIS -------------
   std::string configFilename = "aegis_settings.json";
-  auto configFile = std::make_shared<InputJSON>(configFilename);
+  auto configFile = std::make_shared<JsonHandler>(configFilename);
 
   auto equilibrium = std::make_shared<EquilData>();
   equilibrium->setup(configFile);
@@ -114,14 +114,14 @@ double dot_product(std::vector<double> vector_a, std::vector<double> vector_b);
 
   double Q_rel_sum = 0.0;
 
-  std::cout << aegis.num_facets();
+  std::cout << aegis.target_num_facets();
 
-  for (int i=0; i<aegis.num_facets(); i++){
+  for (int i=0; i<aegis.target_num_facets(); i++){
     Q_rel_sum += std::pow((aegis.psiQ_values[i].second - smardda_qValues[i].second), 2);
   }
 
 
-  double L2_NORM = std::sqrt( (1.0/aegis.num_facets())*Q_rel_sum );
+  double L2_NORM = std::sqrt( (1.0/aegis.target_num_facets())*Q_rel_sum );
   const double EXPECTED_L2_NORM = 349791;
 
   const auto AEGIS_MAX = *std::max_element(aegis.psiQ_values.begin(),aegis.psiQ_values.end(),[](const auto& lhs, const auto& rhs) { return lhs.second < rhs.second; });

--- a/test/unit/aegis_unit.cpp
+++ b/test/unit/aegis_unit.cpp
@@ -335,13 +335,12 @@ TEST_F(aegisUnitTest, eqdsk_read) {
 }
 
 
-TEST_F(aegisUnitTest, cart_polar_coord_transform){
+TEST_F(aegisUnitTest, cart_to_polar_transform){
   std::vector<double> input = {2.4, 5.3, -2.0};
   std::vector<double> output;
-  std::string direction;
   output.reserve(3);
 
-  output = CoordTransform::cart_to_polar(input, direction);
+  output = CoordTransform::cart_to_polar(input);
 
   EXPECT_FLOAT_EQ(output[0], 5.8180752);
   EXPECT_FLOAT_EQ(output[1], -2);
@@ -349,7 +348,20 @@ TEST_F(aegisUnitTest, cart_polar_coord_transform){
 
 }
 
-TEST_F(aegisUnitTest, polar_flux_coord_transform){
+TEST_F(aegisUnitTest, polar_to_cart_transform){
+  std::vector<double> input = {5.8180752, -2.0, -1.1455913};
+  std::vector<double> output;
+  output.reserve(3);
+
+  output = CoordTransform::polar_to_cart(input);
+
+  EXPECT_FLOAT_EQ(output[0], 2.4);
+  EXPECT_FLOAT_EQ(output[1], 5.3);
+  EXPECT_FLOAT_EQ(output[2], -2.0);
+
+}
+
+TEST_F(aegisUnitTest, polar_to_flux_transform){
 
   auto equilibrium = std::make_shared<EquilData>();
   equilibrium->read_eqdsk("test.eqdsk");
@@ -361,7 +373,7 @@ TEST_F(aegisUnitTest, polar_flux_coord_transform){
   std::string direction;
   output.reserve(3);
 
-  output = CoordTransform::polar_to_flux(input, direction, equilibrium);
+  output = CoordTransform::polar_to_flux(input, equilibrium);
 
   EXPECT_FLOAT_EQ(output[0], -2.5001357);
   EXPECT_FLOAT_EQ(output[1], 2.1932724);


### PR DESCRIPTION
Biggest change is the new logic to handle parameters specified in the config file of a run. AEGIS will now exit out if certain `required` parameters are not present in the config file. These required parameters include:
- `aegis_params: {DAGMC}` - DAGMC .h5m input file
- `equil_params: {eqdsk}` - .eqdsk file required for magnetic equilibrium
- `equil_params: {power_sol}` - Power at the scrape-off-layer used in the Eich formula for power deposition calculations
- `equil_params: {lambda_q}` - Scrape-off-layer width used in the Eich formula for power deposition calculations
- `equil_params: {r_outrbdry}` - R at the last closed flux surface used in both the Eich formula and as a check to terminate particle when reaching outer midplane

Any other runtime parameters are deemed `optional` and will take on default values if no values are specified in the config json. Full list of changes below:

Changelist
-
- Specification of `required` and `optional` parameters in AEGIS runs (see above)
- Ensured all optional parameters have default values specified in header file. **TODO - Add comments to each variable which shows the default value**
- Renamed `InputJSON` class to `JsonHandler` and added two new template methods to facilitate the return of optional and required parameters - `JsonHandler::get_required<T>()` and `JsonHandler::get_optional<T>()`
- Restructured `EquilData` constructor and removed `EquilData::setup()` as this function was essentially acting as the constructor. Also added a similar `read_params` function to EquilData to handle reading parameters. Perhaps there is a way to make this a part of `AegisBase` and pass it a structure that contains all of the parameters for each class
- New method that calls `MPI_Abort` `AegisBase::error_abort_mpi()`. This function feels mostly redundant as all it does is call `MPI_Abort` and `std::cerr << "Terminating program...;` however I could not call `MPI_Abort` directly in a header file (since I could not include the mpi.h file in another header) so this is a work around
- Separated CoordTransform methods into distinct functions for forwards and backwards functions instead of relying on a branching checking parameters. I think this makes the AEGIS API a little bit cleaner as it is more explicit. I.e. `cart_to_polar(vec, direction) --> cart_to_polar(vec) + polar_to_cart(vec)`
- `ParticleBase` constructor now requires that a particle is instantiated with a position vector. This was done in an attempt to make the class more consistent when handling different coordinate systems.
- `ParticleBase::check_if_in_bfield()` method has been removed in favour of making this method a part of the `EquilData` class. Made sense as the original method would require `EquilData` object to be passed into `ParticleBase`
- Switch statement to handle different coordinate systems added to `ParticleBase::check_if_midplane_crossed()`. I'm not convinced this is working as intended as when running in different coordinate systems things still dont look right.
- Moved `DagMC::RayHistory` object into the `ParticleBase` class as it makes sense to keep the two linked
- New function `ParticleSimulation::test_cyl_ray_fire()` to test ray fire in a different coordinate system (not currently working)
- Various small code refactors and variable name changes
- Moved some particle setup logic into `ParticleSimulation::loop_over_particle_track` in preparation for the addition of new methods to handle particle tracking in different coordinate systems. Ideally `ParticleSimulation::loop_over_factets()` is called no matter what and will contain a switch to call the different particle tracking methods associated with different coordinate systems
