### PR TITLE
progress bar and minor QOL fixes

### DIFF
--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -1,5 +1,6 @@
 {
   "description": "inres1 test case to compare against SMARDDA",
+  "global_params": {"mpi_timings": false},
   "aegis_params":{
       "DAGMC": "inres1_shad.h5m",
       "step_size": 0.01,
@@ -9,10 +10,11 @@
       "force_no_deposition": false,
       "coordinate_system": "flux",
       "execution_type": "dynamic",
+      "print_mpi_particle_stats":false,
       "dynamic_batch_params":{
           "batch_size":16,
           "worker_profiling": false,
-	      "worker_debug":false
+          "worker_debug":false
       } 
   },
   "equil_params":{

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -44,15 +44,29 @@ main(int argc, char ** argv)
   ParticleSimulation simulation(configFile, equilibrium);
   simulation.Execute();
 
-  for (int i = 0; i < nprocs; ++i)
+  auto mpiTimings = configFile->data()["global_params"]["mpi_timings"];
+
+  if (mpiTimings) // print individual timings for each MPI rank
   {
-    if (rank == i)
+    for (int i = 1; i < nprocs; ++i)
     {
-      double endTime = MPI_Wtime();
-      double totalTime = endTime - startTime;
-      std::cout << "Elapsed wall Time on process " << i << " = " << totalTime << std::endl;
-      std::cout << "----------------------------" << std::endl << std::endl;
+      if (rank == i)
+      {
+        double endTime = MPI_Wtime();
+        double totalTime = endTime - startTime;
+        std::cout << "Elapsed wall Time on process " << i << " = " << totalTime << "\n";
+        std::cout << "---------------------------- \n \n";
+      }
     }
+  }
+
+  if (rank == 0) // print final wall time once rank 0 is complete
+  {
+    double endTime = MPI_Wtime();
+    double totalTime = endTime - startTime;
+    std::cout << "\n---------------------------- \n";
+    std::cout << "Total elapsed wall Time = " << totalTime << "\n";
+    std::cout << "---------------------------- \n" << std::endl;
   }
 
   MPI_Finalize();

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -122,11 +122,11 @@ class ParticleSimulation : public AegisBase
   void write_out_mesh(meshWriteOptions option, moab::Range rangeOfEntities = {});
   void mesh_coord_transform(coordinateSystem coordSys);
   void select_coordinate_system();
-  
+  void update_progress_indicator(int batchesComplete, int totalBatches);
+
   // Simulation config parameters
-  std::string exeType = "dynamic";
-  std::string dagmcInputFile; // no defaults because 
-  std::string eqdskInputFile;
+  std::string executionType = "dynamic";
+  std::string dagmcInputFile; // parameter required to be specified by user
   double powerSOL = 0.0;
   double lambdaQ = 0.0; 
   double trackStepSize = 0.001;
@@ -139,6 +139,7 @@ class ParticleSimulation : public AegisBase
   bool workerDebug = false;
   coordinateSystem coordSys = coordinateSystem::CARTESIAN; // default cartesian 
   bool noMidplaneTermination = false;
+  bool printMpiParticleStats = false;
 
   std::vector<TriangleSource> listOfTriangles;
   int totalNumberOfFacets = 0;


### PR DESCRIPTION
Very small PR which adds a better progress bar to the ParticleSimulation. Current implementation relies on a for loop of 10 iterations calling an if statement to check how much work has been completed. Perhaps this would cause some slowdown. **Before merging this in with master maybe some profiling should be completed**. Full changelist below:

Changelist
-
- New `private ParticleSimulation::update_progress_indicator()` method that calls to update the progress indicator every 10% that is complete. This works for both the dynamic_mpi and serial runs (may need a different function for no_load_balanced_mpi)
- Added a new flag to the `main` function that queries the json for an `"global_params": {"mpi_timings"}` parameter. When present and set to true AEGIS will print individual mpi rank timings to console (useful for debugging slow processes)
- By default AEGIS will always print total elapsed wall time on process 0 but will only print other wall times when this flag is present
- Renamed member variable `ParticleSimulation::exeType` to `ParticleSimulation::execution_type` to be more explicit in its intent
- `ParticleSimulation::mpi_particle_stats` method is only called when `"aegis_params":{"print_mpi_particle_stats": true}`