### PR TITLE
Feature/mc particle launch

### DIFF
--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -9,6 +9,7 @@
       "force_no_deposition": false,
       "coordinate_system": "flux",
       "execution_type": "dynamic",
+      "number_of_particles_per_facet":5,
       "dynamic_batch_params":{
           "batch_size":16,
           "worker_profiling": false,
@@ -28,6 +29,6 @@
       "print_debug_info": false
   },
   "vtk_params":{
-      "draw_particle_tracks": false
+      "draw_particle_tracks": true
   }
  }

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -4,7 +4,7 @@
       "DAGMC": "inres1_shad.h5m",
       "step_size": 0.01,
       "max_steps": 10000,
-      "launch_pos": "fixed",
+      "launch_pos": "mc",
       "target_surfs": [1,2,3,4,5,6],
       "force_no_deposition": false,
       "coordinate_system": "flux",

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -44,18 +44,21 @@ main(int argc, char ** argv)
   ParticleSimulation simulation(configFile, equilibrium);
   simulation.Execute();
 
-  for (int i = 0; i < nprocs; ++i)
-  {
-    if (rank == i)
-    {
-      double endTime = MPI_Wtime();
-      double totalTime = endTime - startTime;
-      std::cout << "Elapsed wall Time on process " << i << " = " << totalTime << std::endl;
-      std::cout << "----------------------------" << std::endl << std::endl;
-    }
-  }
+  // for (int i = 1; i < nprocs; ++i)
+  // {
+  //   if (rank == i)
+  //   {
+  //     double endTime = MPI_Wtime();
+  //     double totalTime = endTime - startTime;
+  //     std::cout << "Elapsed wall Time on process " << i << " = " << totalTime << std::endl;
+  //     std::cout << "----------------------------" << std::endl << std::endl;
+  //   }
+  // }
 
   MPI_Finalize();
-
+  if (rank == 0)
+  {
+    std::cout << "Total wall time = " << MPI_Wtime() - startTime << "s" << std::endl;
+  }
   return 0;
 }

--- a/src/aegis_lib/EquilData.cpp
+++ b/src/aegis_lib/EquilData.cpp
@@ -1406,7 +1406,7 @@ EquilData::get_midplane_params()
 }
 
 // check if in b_field from polar coords (R,Z)
-void
+bool
 EquilData::check_if_in_bfield(std::vector<double> xyzPos)
 {
   std::vector<double> polarPos = CoordTransform::cart_to_polar(xyzPos);
@@ -1414,6 +1414,7 @@ EquilData::check_if_in_bfield(std::vector<double> xyzPos)
   double z = polarPos[1];
   if (r < rmin || r > rmax || z < zmin || z > zmax)
   {
-    throw std::runtime_error("Position outside magnetic field");
+    return false;
   }
+  return true;
 }

--- a/src/aegis_lib/EquilData.h
+++ b/src/aegis_lib/EquilData.h
@@ -135,7 +135,7 @@ class EquilData : public AegisBase
 
   void psiref_override();
 
-  void check_if_in_bfield(std::vector<double> xyzPos);
+  bool check_if_in_bfield(std::vector<double> xyzPos);
 
   std::array<double, 3> get_midplane_params(); // return rInnerMidplane, rOuterMidplane, zMidplane
 

--- a/src/aegis_lib/ParticleSimulation.cpp
+++ b/src/aegis_lib/ParticleSimulation.cpp
@@ -16,13 +16,13 @@ ParticleSimulation::ParticleSimulation(std::shared_ptr<JsonHandler> configFile,
 }
 
 void
-ParticleSimulation::test_cyl_ray_fire(std::unique_ptr<ParticleBase> & particle)
+ParticleSimulation::test_cyl_ray_fire(ParticleBase & particle)
 {
 
   std::ofstream coordinateTest("coords.txt");
   std::ofstream coordinateTest2("coords2.txt");
-  std::vector<double> cartPos = particle->pos;
-  std::vector<double> bfieldXYZ = particle->dir;
+  std::vector<double> cartPos = particle.pos;
+  std::vector<double> bfieldXYZ = particle.dir;
   std::vector<double> polPos = CoordTransform::cart_to_polar(cartPos);
   std::vector<double> bFieldRZ = equilibrium->b_field(cartPos, "");
 
@@ -498,45 +498,31 @@ ParticleSimulation::loop_over_facets(int startFacet, int endFacet)
   double startTime = MPI_Wtime();
   std::vector<double> heatfluxVals;
 
-  std::vector<double> triCoords(9);
-  std::vector<double> triA(3), triB(3), triC(3);
-
   // main loop over all facets
   for (int i = startFacet; i < endFacet; ++i)
   { // loop over all facets
     double heatflux = 0.0;
     double averagedHeatflux = 0.0;
-    auto tri = listOfTriangles[i];
+    auto triangle = listOfTriangles[i];
 
     if (i >= targetFacets.size()) // handle padded values
     {
-      tri.update_heatflux(-1);
+      triangle.update_heatflux(-1);
       integrator->count_particle(0, terminationState::PADDED, 0.0);
       continue;
     }
+    double heatfluxOnFacet = 0.0;
 
-    // loop over particles per facet
-    for (int j = 0; j < nParticlesPerFacet; ++j)
+    if (particleLaunchPos == "fixed")
     {
-      std::vector<double> launchPos = tri.random_pt();
-      auto particle = std::make_unique<ParticleBase>(coordSys, launchPos);
-      try
-      {
-        equilibrium->check_if_in_bfield(launchPos);
-      }
-      catch (std::runtime_error & e)
-      {
-        log_string(LogLevel::INFO, "Particle start out of bounds. Skipping to next triangle...");
-        terminate_particle_lost(tri);
-        continue;
-      }
-      integrator->set_launch_position(tri.entity_handle(), launchPos);
-      double particleHeat = tri.heatflux() / nParticlesPerFacet;
-      terminationState particleState = loop_over_particle_track(tri, particle);
-      heatflux = (particleState == terminationState::DEPOSITING) ? particleHeat : 0.0;
-      averagedHeatflux += heatflux;
+      heatfluxOnFacet = fixed_particle_launch(triangle);
     }
-    heatfluxVals.push_back(averagedHeatflux);
+    else
+    {
+      heatfluxOnFacet = monte_carlo_particle_launch(triangle);
+    }
+
+    heatfluxVals.push_back(heatfluxOnFacet);
   }
 
   double endTime = MPI_Wtime();
@@ -549,55 +535,97 @@ ParticleSimulation::loop_over_facets(int startFacet, int endFacet)
   return heatfluxVals;
 }
 
+double
+ParticleSimulation::monte_carlo_particle_launch(TriangleSource triangle)
+{
+  double heatflux = 0.0;
+  double averagedHeatflux = 0.0;
+
+  for (int j = 0; j < nParticlesPerFacet; ++j)
+  {
+    std::vector<double> launchPos = triangle.random_pt();
+    ParticleBase particle(coordSys, launchPos);
+    if (!equilibrium->check_if_in_bfield(launchPos))
+    {
+      log_string(LogLevel::INFO,
+                 "Particle start out of magnetic field bounds. Skipping to next particle...");
+      terminate_particle_lost(triangle);
+      continue;
+    }
+    integrator->set_launch_position(triangle.entity_handle(), launchPos);
+    double particleHeat = triangle.heatflux() / nParticlesPerFacet;
+    terminationState particleState = cartesian_particle_track(triangle, particle);
+    heatflux = (particleState == terminationState::DEPOSITING) ? particleHeat : 0.0;
+    averagedHeatflux += heatflux;
+  }
+  return averagedHeatflux;
+}
+
+double
+ParticleSimulation::fixed_particle_launch(TriangleSource triangle)
+{
+  std::vector<double> launchPos = triangle.launch_pos();
+  ParticleBase particle(coordSys, launchPos);
+  if (!equilibrium->check_if_in_bfield(launchPos))
+  {
+    log_string(LogLevel::INFO,
+               "Particle start out of magnetic field bounds. Skipping to next particle...");
+    terminate_particle_lost(triangle);
+    return 0.0;
+  }
+  integrator->set_launch_position(triangle.entity_handle(), launchPos);
+  double particleHeat = triangle.heatflux() / nParticlesPerFacet;
+  terminationState particleState = cartesian_particle_track(triangle, particle);
+  double heatflux = (particleState == terminationState::DEPOSITING) ? heatflux : 0.0;
+
+  return heatflux;
+}
+
 void
 ParticleSimulation::setup_sources()
 {
 
-  std::vector<double> triCoords(9);
-  std::vector<double> triA(3), triB(3), triC(3);
+  std::vector<double> triangleCoords(9);
+  std::vector<double> trianglePtsA(3), trianglePtsB(3), trianglePtsC(3);
   for (const auto & facet : targetFacets)
   {
-    std::vector<moab::EntityHandle> triNodes;
-    DAG->moab_instance()->get_adjacencies(&facet, 1, 0, false, triNodes);
-    DAG->moab_instance()->get_coords(&triNodes[0], triNodes.size(), triCoords.data());
+    std::vector<moab::EntityHandle> triangleNodes;
+    DAG->moab_instance()->get_adjacencies(&facet, 1, 0, false, triangleNodes);
+    DAG->moab_instance()->get_coords(&triangleNodes[0], triangleNodes.size(),
+                                     triangleCoords.data());
 
     for (int j = 0; j < 3; j++)
     {
-      triA[j] = triCoords[j];
-      triB[j] = triCoords[j + 3];
-      triC[j] = triCoords[j + 6];
+      trianglePtsA[j] = triangleCoords[j];
+      trianglePtsB[j] = triangleCoords[j + 3];
+      trianglePtsC[j] = triangleCoords[j + 6];
     }
 
-    TriangleSource tri(triA, triB, triC, facet, particleLaunchPos);
-
-    try
-    {
-      equilibrium->check_if_in_bfield(tri.launch_pos());
-      tri.set_heatflux_params(equilibrium, "exp");
-    }
-    catch (std::runtime_error & e)
+    TriangleSource triangle(trianglePtsA, trianglePtsB, trianglePtsC, facet, particleLaunchPos);
+    if (!equilibrium->check_if_in_bfield(triangle.launch_pos()))
     {
       log_string(LogLevel::INFO,
                  "Triangle start outside of magnetic field. Skipping to next triangle...");
+      continue;
     }
-    listOfTriangles.push_back(tri);
+    triangle.set_heatflux_params(equilibrium, "exp");
+    listOfTriangles.push_back(triangle);
   }
 }
 
 // loop over single particle track from launch to termination
 terminationState
-ParticleSimulation::loop_over_particle_track(TriangleSource & tri,
-                                             std::unique_ptr<ParticleBase> & particle)
+ParticleSimulation::cartesian_particle_track(TriangleSource & triangle, ParticleBase & particle)
 {
   double euclidDistToNextSurf = 0.0;
   nextSurf = 0;
-  particle->set_pos(tri.launch_pos());
-  particle->set_dir(equilibrium);
-  particle->align_dir_to_surf(tri.BdotN());
+  particle.set_pos(triangle.launch_pos());
+  particle.set_dir(equilibrium);
+  particle.align_dir_to_surf(triangle.BdotN());
   // test_cyl_ray_fire(particle);
 
   vtkInterface->init_new_vtkPoints();
-  vtkInterface->insert_next_point_in_track(particle->get_xyz_pos());
+  vtkInterface->insert_next_point_in_track(particle.get_xyz_pos());
   moab::DagMC::RayHistory history;
 
   for (int step = 0; step < maxTrackSteps; ++step)
@@ -605,58 +633,54 @@ ParticleSimulation::loop_over_particle_track(TriangleSource & tri,
     trackLength += trackStepSize;
     iterationCounter++;
 
-    DAG->ray_fire(implComplementVol, particle->pos.data(), particle->dir.data(), nextSurf,
+    DAG->ray_fire(implComplementVol, particle.pos.data(), particle.dir.data(), nextSurf,
                   nextSurfDist, &history, trackStepSize, rayOrientation);
     numberOfRayFireCalls++;
 
     if (nextSurf != 0)
     {
-      particle->update_vectors(nextSurfDist); // update position to surface intersection point
-      terminate_particle_shadow(tri);
+      particle.update_vectors(nextSurfDist); // update position to surface intersection point
+      terminate_particle_shadow(triangle);
       return terminationState::SHADOWED;
     }
     else
     {
-      particle->update_vectors(trackStepSize); // update position by stepsize
+      particle.update_vectors(trackStepSize); // update position by stepsize
     }
 
-    vtkInterface->insert_next_point_in_track(particle->get_xyz_pos());
+    vtkInterface->insert_next_point_in_track(particle.get_xyz_pos());
 
-    try
+    if (!equilibrium->check_if_in_bfield(particle.pos))
     {
-      equilibrium->check_if_in_bfield(particle->pos);
-    }
-    catch (std::runtime_error & e)
-    {
-      terminate_particle_lost(tri);
+      terminate_particle_lost(triangle);
       return terminationState::LOST;
     }
 
-    particle->set_dir(equilibrium);
-    particle->align_dir_to_surf(tri.BdotN());
-    particle->check_if_midplane_crossed(equilibrium->get_midplane_params());
+    particle.set_dir(equilibrium);
+    particle.align_dir_to_surf(triangle.BdotN());
+    particle.check_if_midplane_crossed(equilibrium->get_midplane_params());
 
-    if (particle->atMidplane != 0 && !noMidplaneTermination)
+    if (particle.atMidplane != 0 && !noMidplaneTermination)
     {
-      terminate_particle_depositing(tri);
+      terminate_particle_depositing(triangle);
       return terminationState::DEPOSITING;
     }
   }
 
-  particle->set_facet_history(history);
+  particle.set_facet_history(history);
   // max length of particle track reached
-  terminate_particle_maxlength(tri);
+  terminate_particle_maxlength(triangle);
   return terminationState::MAXLENGTH;
 }
 
 // terminate particle after reaching midplane
 void
-ParticleSimulation::terminate_particle_depositing(TriangleSource & tri)
+ParticleSimulation::terminate_particle_depositing(TriangleSource & triangle)
 {
   std::stringstream terminationLogString;
-  double heatflux = tri.heatflux();
+  double heatflux = triangle.heatflux();
   vtkInterface->write_particle_track(branchDepositingPart, heatflux);
-  integrator->count_particle(tri.entity_handle(), terminationState::DEPOSITING, heatflux);
+  integrator->count_particle(triangle.entity_handle(), terminationState::DEPOSITING, heatflux);
   terminationLogString << "Midplane reached. Depositing power after travelling " << trackLength
                        << " units";
   log_string(LogLevel::INFO, terminationLogString.str());
@@ -664,12 +688,12 @@ ParticleSimulation::terminate_particle_depositing(TriangleSource & tri)
 
 // terminate particle after hitting shadowing geometry
 void
-ParticleSimulation::terminate_particle_shadow(TriangleSource & tri)
+ParticleSimulation::terminate_particle_shadow(TriangleSource & triangle)
 {
   std::stringstream terminationLogString;
   double heatflux = 0.0;
   vtkInterface->write_particle_track(branchShadowedPart, heatflux);
-  integrator->count_particle(tri.entity_handle(), terminationState::SHADOWED, heatflux);
+  integrator->count_particle(triangle.entity_handle(), terminationState::SHADOWED, heatflux);
   terminationLogString << "Surface " << nextSurf << " hit after travelling " << trackLength
                        << " units";
   log_string(LogLevel::INFO, terminationLogString.str());
@@ -677,12 +701,12 @@ ParticleSimulation::terminate_particle_shadow(TriangleSource & tri)
 
 // terminate particle after leaving magnetic field
 void
-ParticleSimulation::terminate_particle_lost(TriangleSource & tri)
+ParticleSimulation::terminate_particle_lost(TriangleSource & triangle)
 {
   std::stringstream terminationLogString;
   double heatflux = 0.0;
   vtkInterface->write_particle_track(branchLostPart, heatflux);
-  integrator->count_particle(tri.entity_handle(), terminationState::LOST, heatflux);
+  integrator->count_particle(triangle.entity_handle(), terminationState::LOST, heatflux);
   terminationLogString << "Particle leaving magnetic field after travelling " << trackLength
                        << " units";
   log_string(LogLevel::INFO, terminationLogString.str());
@@ -690,31 +714,14 @@ ParticleSimulation::terminate_particle_lost(TriangleSource & tri)
 
 // terminate particle after travelling user specified max distance
 void
-ParticleSimulation::terminate_particle_maxlength(TriangleSource & tri)
+ParticleSimulation::terminate_particle_maxlength(TriangleSource & triangle)
 {
   std::stringstream terminationLogString;
   double heatflux = 0.0;
   vtkInterface->write_particle_track(branchMaxLengthPart, heatflux);
-  integrator->count_particle(tri.entity_handle(), terminationState::MAXLENGTH, heatflux);
+  integrator->count_particle(triangle.entity_handle(), terminationState::MAXLENGTH, heatflux);
   terminationLogString << "Fieldline trace reached maximum length before intersection";
 }
-
-// void
-// ParticleSimulation::ray_hit_on_launch(std::unique_ptr<ParticleBase> & particle)
-// {
-//   DAG->ray_fire(implComplementVol, particle->launchPos.data(), particle->dir.data(), nextSurf,
-//                 nextSurfDist, particle->facet_history(), trackStepSize, rayOrientation);
-//   if (nextSurf != 0)
-//   {
-//     particle->history.get_last_intersection(intersectedFacet);
-//     EntityHandle nextVolEH;
-//     DAG->next_vol(nextSurf, implComplementVol, nextVolEH);
-//     if (rank == 0)
-//     {
-//       LOG_INFO << "---- RAY HIT ON LAUNCH [" << facetCounter << "] ----";
-//     }
-//   }
-// }
 
 // Get triangles from the surface(s) of interest
 moab::Range

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -97,19 +97,21 @@ class ParticleSimulation : public AegisBase
   void implicit_complement_testing(); 
   moab::Range select_target_surface(); // get target surfaces of interest from aegis_settings.json
   std::vector<double> loop_over_facets(int startFacet, int endFacet); // loop over facets in target surfaces
-  
+  double monte_carlo_particle_launch(TriangleSource triangle);
+  double fixed_particle_launch(TriangleSource triangle);
+
   void setup_sources();
 
   void cartesian_track();
   void polar_track();
   void flux_track();
   
-  terminationState loop_over_particle_track(TriangleSource&tri, std::unique_ptr<ParticleBase> &particle); // loop over individual particle tracks
-  void terminate_particle_depositing(TriangleSource&tri); // end particle track
-  void terminate_particle_shadow(TriangleSource&tri); // end particle track
-  void terminate_particle_lost(TriangleSource&tri); // end particle track
-  void terminate_particle_maxlength(TriangleSource&tri); // end particle track
-  void test_cyl_ray_fire(std::unique_ptr<ParticleBase> &particle);  
+  terminationState cartesian_particle_track(TriangleSource &triangle, ParticleBase &particle); // loop over individual particle tracks
+  void terminate_particle_depositing(TriangleSource &triangle); // end particle track
+  void terminate_particle_shadow(TriangleSource &triangle); // end particle track
+  void terminate_particle_lost(TriangleSource &triangle); // end particle track
+  void terminate_particle_maxlength(TriangleSource &triangle); // end particle track
+  void test_cyl_ray_fire(ParticleBase &particle);  
   
   
   void ray_hit_on_launch(std::unique_ptr<ParticleBase> &particle); // particle hit on initial launch from surface

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -139,6 +139,7 @@ class ParticleSimulation : public AegisBase
   bool workerDebug = false;
   coordinateSystem coordSys = coordinateSystem::CARTESIAN; // default cartesian 
   bool noMidplaneTermination = false;
+  int nParticlesPerFacet = 1; // Number of particles launched per facet
 
   std::vector<TriangleSource> listOfTriangles;
   int totalNumberOfFacets = 0;


### PR DESCRIPTION
Major thing here is the addition of a new method to handle multiple particles being launched from random positions on a facet surface. This will be necessary for a monte-carlo backwards problem into a source with some kind of probability distribution. Also allows for an easier way to scale up the problem for scaling studies on HPC architecture.

Some other QOL changes such as variable renaming have also been included. Full changelist below:

Changelist
-
- Restructured `ParticleSimulation::loop_over_facets()` to call one of two new methods. If the user specifies a fixed position for particle launches then `fixed_particle_launch()` and launches a single particle. Otherwise `monte_carlo_particle_launch()` is called which loops over a number of particles specified by the user. Each particle is launched from a random position
- Removed depreciated code
- Replaced `EquilData::check_if_in_bfield()` `try throw catch` logic with a simple `return bool` which can be checked against
- Renamed ambiguous variables (namely `tri` --> `triangle`)