### PR TITLE
Feature/mc particle launch

### DIFF
--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -9,7 +9,7 @@
       "force_no_deposition": false,
       "coordinate_system": "flux",
       "execution_type": "dynamic",
-      "number_of_particles_per_facet":5,
+      "number_of_particles_per_facet":2,
       "dynamic_batch_params":{
           "batch_size":16,
           "worker_profiling": false,

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -4,10 +4,10 @@
       "DAGMC": "inres1_shad.h5m",
       "step_size": 0.01,
       "max_steps": 10000,
-      "launch_pos": "mc",
+      "launch_pos": "fixed",
 
       "monte_carlo_params":{
-            "number_of_particles_per_facet":2,
+            "number_of_particles_per_facet":4,
             "write_particle_launch_positions":true
       },
 

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -4,11 +4,11 @@
       "DAGMC": "inres1_shad.h5m",
       "step_size": 0.01,
       "max_steps": 10000,
-      "launch_pos": "fixed",
+      "launch_pos": "mc",
 
       "monte_carlo_params":{
-            "number_of_particles_per_facet":4,
-            "write_particle_launch_positions":true
+            "number_of_particles_per_facet":5,
+            "write_particle_launch_positions":false
       },
 
       "target_surfs": [1,2,3,4,5,6],
@@ -19,7 +19,7 @@
       "dynamic_batch_params":{
           "batch_size":16,
           "worker_profiling": false,
-	      "worker_debug":false
+	  "debug":false
       } 
   },
   "equil_params":{
@@ -35,6 +35,6 @@
       "print_debug_info": false
   },
   "vtk_params":{
-      "draw_particle_tracks": true
+      "draw_particle_tracks": false
   }
  }

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -5,11 +5,17 @@
       "step_size": 0.01,
       "max_steps": 10000,
       "launch_pos": "mc",
+
+      "monte_carlo_params":{
+            "number_of_particles_per_facet":2,
+            "write_particle_launch_positions":true
+      },
+
       "target_surfs": [1,2,3,4,5,6],
       "force_no_deposition": false,
       "coordinate_system": "flux",
       "execution_type": "dynamic",
-      "number_of_particles_per_facet":2,
+
       "dynamic_batch_params":{
           "batch_size":16,
           "worker_profiling": false,

--- a/src/aegis/aegis.cpp
+++ b/src/aegis/aegis.cpp
@@ -58,7 +58,7 @@ main(int argc, char ** argv)
   MPI_Finalize();
   if (rank == 0)
   {
-    std::cout << "Total wall time = " << MPI_Wtime() - startTime << "s" << std::endl;
+    std::cout << "Total wall time = " << MPI_Wtime() - startTime << std::endl;
   }
   return 0;
 }

--- a/src/aegis_lib/Particle.h
+++ b/src/aegis_lib/Particle.h
@@ -17,22 +17,27 @@
 #include "CoordTransform.h"
 #include "EquilData.h"
 
-
+enum class magneticFieldDirection
+{
+  FORWARDS,
+  BACKWARDS
+};
 
 class ParticleBase : public AegisBase
 {
   private:
-  double power = 0.0; // power associated with particle
+  double _heatflux = 0.0; // heatflux associated with particle
   double lengthTravelled = 0.0; // total length travelled by particle
   bool directionUp = false; 
   std::vector<double> previousPos; // previous position in particle history
   double thresholdDistanceThreshold = 0.0;
   double euclidDistTravelled = 0.0;
   bool thresholdDistanceCrossed = false;
-  moab::DagMC::RayHistory facetHistory;
+  moab::DagMC::RayHistory facetHistory; // stores entity handles of surfaces crossed and facets hit
+  moab::EntityHandle parentEntity;
+  magneticFieldDirection fieldDir = magneticFieldDirection::BACKWARDS; // set particle along or against magnetic field 
   
   coordinateSystem coordSystem = coordinateSystem::CARTESIAN;
-  //DagMC::RayHistory history; // stores entity handles of surfaces crossed and facets hit
 
   public:
   std::vector<double> Bfield; // magnetic field at current pos
@@ -46,8 +51,10 @@ class ParticleBase : public AegisBase
 
 
 
+  ParticleBase(coordinateSystem coordSys, std::vector<double> startingPosition, double heatflux, moab::EntityHandle entityHandle);  
+  ParticleBase(coordinateSystem coordSys, std::vector<double> startingPosition, double heatflux);  
+  ParticleBase(coordinateSystem coordSys, std::vector<double> startingPosition); 
 
-  ParticleBase(coordinateSystem coordSys, std::vector<double> startingPosition);  
   void set_facet_history(moab::DagMC::RayHistory history);
 
   // set new particle position
@@ -71,7 +78,8 @@ class ParticleBase : public AegisBase
   void check_if_midplane_crossed(const std::array<double, 3> &midplaneParameters); // check if particle has reached inner or outer midplane and set value of atMidplane
   void set_intersection_threshold(double distanceThreshold);
   bool check_if_threshold_crossed();
-
+  double heatflux();
+  moab::EntityHandle parent_entity_handle();
 };
 
 

--- a/src/aegis_lib/ParticleSimulation.cpp
+++ b/src/aegis_lib/ParticleSimulation.cpp
@@ -27,11 +27,11 @@ ParticleSimulation::test_cyl_ray_fire(ParticleBase & particle)
   std::vector<double> bFieldRZ = equilibrium->b_field(cartPos, "");
 
   std::vector<double> outputPosition1(3), outputPosition2(3);
-  ParticleBase cartParticle(coordinateSystem::CARTESIAN, cartPos);
+  ParticleBase cartParticle(coordinateSystem::CARTESIAN, cartPos, 0.0);
   cartParticle.set_pos(cartPos);
   cartParticle.set_dir(equilibrium);
 
-  ParticleBase polarParticle(coordinateSystem::POLAR, polPos);
+  ParticleBase polarParticle(coordinateSystem::POLAR, polPos, 0.0);
   polarParticle.set_pos(polPos);
   polarParticle.set_dir(equilibrium);
 
@@ -122,24 +122,38 @@ ParticleSimulation::Execute_dynamic_mpi()
 
   const int noMoreWork = -1;
 
-  std::vector<double> handlerQVals(target_num_facets());
-  // int counter = 0;
+  std::vector<double> particleHeatfluxes(target_num_facets() * nParticlesPerFacet);
+  std::vector<double> facetHeatfluxes(target_num_facets());
   setup_sources();
 
   double parallelProfilingStart = MPI_Wtime();
 
   if (rank == 0)
   { // handler process...
-    handler(handlerQVals);
+    handler(particleHeatfluxes);
+    // sum particles over triangles
+    auto particleIter = particleHeatfluxes.begin();
+    for (unsigned int i = 0; i < facetHeatfluxes.size(); ++i)
+    {
+      facetHeatfluxes[i] = std::reduce(particleIter, (particleIter + nParticlesPerFacet));
+      particleIter += nParticlesPerFacet; // step iterator by n particles
+    }
 
-    // for (const auto i:handlerQVals)
-    // {
-    //   file << i << "\n";
-    //   if (i > 0 ) { depositCounter +=1; }
-    // }
-    // file << std::endl;
-    // file << "Number of depositing particles = " << depositCounter <<
-    // std::endl;
+    std::ofstream handlerOutputFile;
+    std::stringstream fileName;
+    fileName << "handler_rank(0).txt";
+    handlerOutputFile.open(fileName.str());
+    int depositCounter = 0;
+    for (const auto i : particleHeatfluxes)
+    {
+      handlerOutputFile << i << "\n";
+      if (i > 0)
+      {
+        depositCounter += 1;
+      }
+    }
+    handlerOutputFile << std::endl;
+    handlerOutputFile << "Number of depositing particles = " << depositCounter << std::endl;
   }
 
   else
@@ -179,8 +193,11 @@ ParticleSimulation::Execute_dynamic_mpi()
     double parallelProfilingEnd = MPI_Wtime();
     std::cout << "Parallel Compute Runtime = " << parallelProfilingEnd - parallelProfilingStart
               << std::endl;
-
-    attach_mesh_attribute("Heatflux", targetFacets, handlerQVals);
+    if (writeParticleLaunchPos == true)
+    {
+      write_particle_launch_positions(particleHeatfluxes);
+    }
+    attach_mesh_attribute("Heatflux", targetFacets, facetHeatfluxes);
     // double meshWriteTimeStart = MPI_Wtime();
     write_out_mesh(meshWriteOptions::BOTH, targetFacets);
     // double meshWriteTime = MPI_Wtime() - meshWriteTimeStart;
@@ -204,22 +221,16 @@ ParticleSimulation::handler(std::vector<double> & handlerQVals)
 
   std::vector<double> workerQVals(dynamicBatchSize);
   std::cout << "Dynamic task scheduling with " << (nprocs - 1) << " processes, each handling "
-            << dynamicBatchSize << " facets" << std::endl;
-  int particlesHandled = 0;
-  int batchesComplete = 0;
-  int totalBatches = target_num_facets() / dynamicBatchSize;
+            << dynamicBatchSize << " particles" << std::endl;
 
+  int particlesHandled = 0;
   for (int procID = 1; procID < nprocs; procID++)
   { // Send the initial indexes for each process statically
     MPI_Send(&particlesHandled, 1, MPI_INT, procID, procID, MPI_COMM_WORLD);
     particlesHandled += dynamicBatchSize;
-    batchesComplete += 1;
   }
 
-  int recvCount = 0;
-
   int inactiveWorkers = 0;
-
   do
   {
     int avaialbleProcess = 0;
@@ -237,8 +248,6 @@ ParticleSimulation::handler(std::vector<double> & handlerQVals)
       // printf("Time taken to recieve next data = %f \n", MPI_Wtime());
 
       particlesHandled += dynamicBatchSize;
-      batchesComplete += 1;
-      // progress indicator
 
       MPI_Wait(&request, MPI_STATUS_IGNORE);
       double * ptr = handlerQVals.data() + workerStartIndex;
@@ -278,70 +287,75 @@ ParticleSimulation::worker()
   int counterDeposit = 0;
   int index = 0;
 
-  if (workerDebug)
-  {
-    // std::ofstream workerOutputFile;
-    // std::stringstream fileName;
-    // fileName << "rank" << rank << ".txt";
-    // workerOutputFile.open(fileName.str());
-    printf("Testing");
-  }
+  // if (workerDebug)
+  // {
+  std::ofstream workerOutputFile;
+  std::stringstream fileName;
+  fileName << "rank" << rank << ".txt";
+  workerOutputFile.open(fileName.str());
+  // }
 
   std::vector<double> workerQVals;
-  int startIndex = 0;
-  MPI_Recv(&startIndex, 1, MPI_INT, 0, rank, MPI_COMM_WORLD, &status);
+  int particleStartIndex = 0;
+  MPI_Recv(&particleStartIndex, 1, MPI_INT, 0, rank, MPI_COMM_WORLD, &status);
 
-  int start = startIndex;
-  int end = start + dynamicBatchSize;
+  unsigned int start = particleStartIndex;
+  unsigned int end = start + dynamicBatchSize;
 
-  workerQVals = loop_over_facets(start, end); // process initial facets
-  // file << "Loop over [" << start << ":" << end << "] facets: \n";
-  // index = start;
-  // for (auto i:workerQVals)
-  // {
-  //   file << "[" << index+1 << "] " <<  i << "\n";
-  //   if (i > 0) { counterDeposit +=1; }
-  //   index +=1;
-  // }
-  // file << std::endl;
+  workerQVals = loop_over_particles(start, end); // process initial facets
+  workerOutputFile << "Loop over [" << start << ":" << end << "] particles: \n";
+  index = start;
+  for (auto i : workerQVals)
+  {
+    workerOutputFile << "[" << index + 1 << "] " << i << "\n";
+    if (i > 0)
+    {
+      counterDeposit += 1;
+    }
+    index += 1;
+  }
+  workerOutputFile << std::endl;
 
   MPI_Send(workerQVals.data(), workerQVals.size(), MPI_DOUBLE, 0, mpiDataTag, MPI_COMM_WORLD);
   MPI_Send(&start, 1, MPI_INT, 0, mpiIndexTag, MPI_COMM_WORLD);
   do
   {
     MPI_Send(&rank, 1, MPI_INT, 0, 1, MPI_COMM_WORLD);
-    MPI_Recv(&startIndex, 1, MPI_INT, 0, 1, MPI_COMM_WORLD, &status);
+    MPI_Recv(&particleStartIndex, 1, MPI_INT, 0, 1, MPI_COMM_WORLD, &status);
 
-    if (startIndex + dynamicBatchSize > target_num_facets())
+    if (particleStartIndex + dynamicBatchSize > target_num_facets())
     {
-      dynamicBatchSize = target_num_facets() - startIndex;
+      dynamicBatchSize = target_num_facets() - particleStartIndex;
     }
 
-    start = startIndex;
+    start = particleStartIndex;
     end = start + dynamicBatchSize;
 
-    if (startIndex != noMoreWork)
+    if (particleStartIndex != noMoreWork)
     { // processing the next set of available work
       // that has been dynamically allocated
-      workerQVals = loop_over_facets(start, end);
+      workerQVals = loop_over_particles(start, end);
       // send local (to worker) array back to handler process
       MPI_Send(workerQVals.data(), workerQVals.size(), MPI_DOUBLE, 0, mpiDataTag, MPI_COMM_WORLD);
       MPI_Send(&start, 1, MPI_INT, 0, mpiIndexTag, MPI_COMM_WORLD);
 
-      // file << "Loop over [" << start << ":" << end << "] facets: \n";
-      // index = start;
-      // for (auto i:workerQVals)
-      // {
-      //   file << "[" << index+1 << "] " <<  i << "\n";
-      //   if (i > 0) { counterDeposit +=1; }
-      //   index +=1;
-      // }
-      // file << std::endl;
+      workerOutputFile << "Loop over [" << start << ":" << end << "] particles: \n";
+      index = start;
+      for (auto i : workerQVals)
+      {
+        workerOutputFile << "[" << index + 1 << "] " << i << "\n";
+        if (i > 0)
+        {
+          counterDeposit += 1;
+        }
+        index += 1;
+      }
+      workerOutputFile << std::endl;
     }
-  } while (startIndex != noMoreWork); // while there is work available
+  } while (particleStartIndex != noMoreWork); // while there is work available
 
-  // file << "Particle Stats:" << std::endl;
-  // file << "Depositing particles = " << counterDeposit << std::endl;
+  workerOutputFile << "Particle Stats:" << std::endl;
+  workerOutputFile << "Depositing particles = " << counterDeposit << std::endl;
 }
 
 // Read parameters from aegis_settings.json config file
@@ -363,6 +377,19 @@ ParticleSimulation::read_params(const std::shared_ptr<JsonHandler> & configFile)
     particleLaunchPos =
         aegisParams.get_optional<std::string>("launch_pos").value_or(particleLaunchPos);
 
+    if (aegisParamsData.contains("monte_carlo_params"))
+    {
+      auto monteCarloParamsData = configFile->data()["aegis_params"]["monte_carlo_params"];
+      JsonHandler monteCarloParams(monteCarloParamsData);
+
+      nParticlesPerFacet = monteCarloParams.get_optional<int>("number_of_particles_per_facet")
+                               .value_or(nParticlesPerFacet);
+
+      writeParticleLaunchPos =
+          monteCarloParams.get_optional<bool>("write_particle_launch_positions")
+              .value_or(writeParticleLaunchPos);
+    }
+
     noMidplaneTermination =
         aegisParams.get_optional<bool>("force_no_deposition").value_or(noMidplaneTermination);
 
@@ -370,9 +397,6 @@ ParticleSimulation::read_params(const std::shared_ptr<JsonHandler> & configFile)
         aegisParams.get_optional<std::string>("coordinate_system").value_or(coordinateConfig);
 
     exeType = aegisParams.get_optional<std::string>("execution_type").value_or(exeType);
-
-    nParticlesPerFacet =
-        aegisParams.get_optional<int>("number_of_particles_per_facet").value_or(nParticlesPerFacet);
 
     if (aegisParamsData.contains("dynamic_batch_params"))
     {
@@ -492,93 +516,30 @@ ParticleSimulation::init_geometry()
 
 // loop over facets in target surfaces
 std::vector<double>
-ParticleSimulation::loop_over_facets(int startFacet, int endFacet)
+ParticleSimulation::loop_over_particles(int startIndex, int endIndex)
 {
-
   double startTime = MPI_Wtime();
   std::vector<double> heatfluxVals;
+  heatfluxVals.reserve(endIndex);
 
   // main loop over all facets
-  for (int i = startFacet; i < endFacet; ++i)
-  { // loop over all facets
-    double heatflux = 0.0;
-    double averagedHeatflux = 0.0;
-    auto triangle = listOfTriangles[i];
-
-    if (i >= targetFacets.size()) // handle padded values
-    {
-      triangle.update_heatflux(-1);
-      integrator->count_particle(0, terminationState::PADDED, 0.0);
-      continue;
-    }
-    double heatfluxOnFacet = 0.0;
-
-    if (particleLaunchPos == "fixed")
-    {
-      heatfluxOnFacet = fixed_particle_launch(triangle);
-    }
-    else
-    {
-      heatfluxOnFacet = monte_carlo_particle_launch(triangle);
-    }
-
-    heatfluxVals.push_back(heatfluxOnFacet);
+  for (int i = startIndex; i < endIndex; ++i)
+  {
+    auto particle = listOfParticles[i];
+    integrator->set_launch_position(particle.parent_entity_handle(), particle.get_pos());
+    terminationState particleState = cartesian_particle_track(particle);
+    double heatflux = (particleState == terminationState::DEPOSITING) ? particle.heatflux() : 0.0;
+    heatfluxVals.emplace_back(heatflux);
   }
 
   double endTime = MPI_Wtime();
   if (workerProfiling)
   {
-    printf("Loop over facets [%d:%d] from rank[%d] time taken = %fs \n", startFacet, endFacet, rank,
+    printf("Loop over facets [%d:%d] from rank[%d] time taken = %fs \n", startIndex, endIndex, rank,
            endTime - startTime);
     fflush(stdout);
   }
   return heatfluxVals;
-}
-
-double
-ParticleSimulation::monte_carlo_particle_launch(TriangleSource triangle)
-{
-  double heatflux = 0.0;
-  double averagedHeatflux = 0.0;
-
-  for (int j = 0; j < nParticlesPerFacet; ++j)
-  {
-    std::vector<double> launchPos = triangle.random_pt();
-    ParticleBase particle(coordSys, launchPos);
-    if (!equilibrium->check_if_in_bfield(launchPos))
-    {
-      log_string(LogLevel::INFO,
-                 "Particle start out of magnetic field bounds. Skipping to next particle...");
-      terminate_particle_lost(triangle);
-      continue;
-    }
-    integrator->set_launch_position(triangle.entity_handle(), launchPos);
-    double particleHeat = triangle.heatflux() / nParticlesPerFacet;
-    terminationState particleState = cartesian_particle_track(triangle, particle);
-    heatflux = (particleState == terminationState::DEPOSITING) ? particleHeat : 0.0;
-    averagedHeatflux += heatflux;
-  }
-  return averagedHeatflux;
-}
-
-double
-ParticleSimulation::fixed_particle_launch(TriangleSource triangle)
-{
-  std::vector<double> launchPos = triangle.launch_pos();
-  ParticleBase particle(coordSys, launchPos);
-  if (!equilibrium->check_if_in_bfield(launchPos))
-  {
-    log_string(LogLevel::INFO,
-               "Particle start out of magnetic field bounds. Skipping to next particle...");
-    terminate_particle_lost(triangle);
-    return 0.0;
-  }
-  integrator->set_launch_position(triangle.entity_handle(), launchPos);
-  double particleHeat = triangle.heatflux() / nParticlesPerFacet;
-  terminationState particleState = cartesian_particle_track(triangle, particle);
-  double heatflux = (particleState == terminationState::DEPOSITING) ? heatflux : 0.0;
-
-  return heatflux;
 }
 
 void
@@ -587,10 +548,12 @@ ParticleSimulation::setup_sources()
 
   std::vector<double> triangleCoords(9);
   std::vector<double> trianglePtsA(3), trianglePtsB(3), trianglePtsC(3);
-  for (const auto & facet : targetFacets)
+  listOfParticles.reserve(target_num_facets() * (nParticlesPerFacet + 1));
+  for (const auto & facetEH : targetFacets)
   {
+    heatfluxMap.insert(std::pair(facetEH, 0.0));
     std::vector<moab::EntityHandle> triangleNodes;
-    DAG->moab_instance()->get_adjacencies(&facet, 1, 0, false, triangleNodes);
+    DAG->moab_instance()->get_adjacencies(&facetEH, 1, 0, false, triangleNodes);
     DAG->moab_instance()->get_coords(&triangleNodes[0], triangleNodes.size(),
                                      triangleCoords.data());
 
@@ -601,7 +564,7 @@ ParticleSimulation::setup_sources()
       trianglePtsC[j] = triangleCoords[j + 6];
     }
 
-    TriangleSource triangle(trianglePtsA, trianglePtsB, trianglePtsC, facet, particleLaunchPos);
+    TriangleSource triangle(trianglePtsA, trianglePtsB, trianglePtsC, facetEH, particleLaunchPos);
     if (!equilibrium->check_if_in_bfield(triangle.launch_pos()))
     {
       log_string(LogLevel::INFO,
@@ -609,19 +572,27 @@ ParticleSimulation::setup_sources()
       continue;
     }
     triangle.set_heatflux_params(equilibrium, "exp");
-    listOfTriangles.push_back(triangle);
+    double psid = triangle.get_psi() + equilibrium->psibdry;
+    double heatflux = equilibrium->omp_power_dep(psid, triangle.BdotN(), "exp");
+    triangle.update_heatflux(heatflux);
+    double heatfluxPerParticle = heatflux / nParticlesPerFacet;
+    for (int i = 0; i < nParticlesPerFacet; ++i)
+    {
+      auto launchPos = (particleLaunchPos == "fixed") ? triangle.centroid() : triangle.random_pt();
+      ParticleBase particle(coordinateSystem::CARTESIAN, launchPos, heatfluxPerParticle, facetEH);
+      particle.align_dir_to_surf(triangle.BdotN());
+      listOfParticles.emplace_back(particle);
+    }
   }
 }
 
 // loop over single particle track from launch to termination
 terminationState
-ParticleSimulation::cartesian_particle_track(TriangleSource & triangle, ParticleBase & particle)
+ParticleSimulation::cartesian_particle_track(ParticleBase & particle)
 {
   double euclidDistToNextSurf = 0.0;
   nextSurf = 0;
-  particle.set_pos(triangle.launch_pos());
   particle.set_dir(equilibrium);
-  particle.align_dir_to_surf(triangle.BdotN());
   // test_cyl_ray_fire(particle);
 
   vtkInterface->init_new_vtkPoints();
@@ -640,7 +611,7 @@ ParticleSimulation::cartesian_particle_track(TriangleSource & triangle, Particle
     if (nextSurf != 0)
     {
       particle.update_vectors(nextSurfDist); // update position to surface intersection point
-      terminate_particle_shadow(triangle);
+      terminate_particle_shadow(particle);
       return terminationState::SHADOWED;
     }
     else
@@ -652,35 +623,35 @@ ParticleSimulation::cartesian_particle_track(TriangleSource & triangle, Particle
 
     if (!equilibrium->check_if_in_bfield(particle.pos))
     {
-      terminate_particle_lost(triangle);
+      terminate_particle_lost(particle);
       return terminationState::LOST;
     }
 
     particle.set_dir(equilibrium);
-    particle.align_dir_to_surf(triangle.BdotN());
     particle.check_if_midplane_crossed(equilibrium->get_midplane_params());
 
     if (particle.atMidplane != 0 && !noMidplaneTermination)
     {
-      terminate_particle_depositing(triangle);
+      terminate_particle_depositing(particle);
       return terminationState::DEPOSITING;
     }
   }
 
   particle.set_facet_history(history);
   // max length of particle track reached
-  terminate_particle_maxlength(triangle);
+  terminate_particle_maxlength(particle);
   return terminationState::MAXLENGTH;
 }
 
 // terminate particle after reaching midplane
 void
-ParticleSimulation::terminate_particle_depositing(TriangleSource & triangle)
+ParticleSimulation::terminate_particle_depositing(ParticleBase & particle)
 {
   std::stringstream terminationLogString;
-  double heatflux = triangle.heatflux();
+  double heatflux = particle.heatflux();
   vtkInterface->write_particle_track(branchDepositingPart, heatflux);
-  integrator->count_particle(triangle.entity_handle(), terminationState::DEPOSITING, heatflux);
+  integrator->count_particle(particle.parent_entity_handle(), terminationState::DEPOSITING,
+                             heatflux);
   terminationLogString << "Midplane reached. Depositing power after travelling " << trackLength
                        << " units";
   log_string(LogLevel::INFO, terminationLogString.str());
@@ -688,12 +659,12 @@ ParticleSimulation::terminate_particle_depositing(TriangleSource & triangle)
 
 // terminate particle after hitting shadowing geometry
 void
-ParticleSimulation::terminate_particle_shadow(TriangleSource & triangle)
+ParticleSimulation::terminate_particle_shadow(ParticleBase & particle)
 {
   std::stringstream terminationLogString;
   double heatflux = 0.0;
   vtkInterface->write_particle_track(branchShadowedPart, heatflux);
-  integrator->count_particle(triangle.entity_handle(), terminationState::SHADOWED, heatflux);
+  integrator->count_particle(particle.parent_entity_handle(), terminationState::SHADOWED, heatflux);
   terminationLogString << "Surface " << nextSurf << " hit after travelling " << trackLength
                        << " units";
   log_string(LogLevel::INFO, terminationLogString.str());
@@ -701,12 +672,12 @@ ParticleSimulation::terminate_particle_shadow(TriangleSource & triangle)
 
 // terminate particle after leaving magnetic field
 void
-ParticleSimulation::terminate_particle_lost(TriangleSource & triangle)
+ParticleSimulation::terminate_particle_lost(ParticleBase & particle)
 {
   std::stringstream terminationLogString;
   double heatflux = 0.0;
   vtkInterface->write_particle_track(branchLostPart, heatflux);
-  integrator->count_particle(triangle.entity_handle(), terminationState::LOST, heatflux);
+  integrator->count_particle(particle.parent_entity_handle(), terminationState::LOST, heatflux);
   terminationLogString << "Particle leaving magnetic field after travelling " << trackLength
                        << " units";
   log_string(LogLevel::INFO, terminationLogString.str());
@@ -714,12 +685,13 @@ ParticleSimulation::terminate_particle_lost(TriangleSource & triangle)
 
 // terminate particle after travelling user specified max distance
 void
-ParticleSimulation::terminate_particle_maxlength(TriangleSource & triangle)
+ParticleSimulation::terminate_particle_maxlength(ParticleBase & particle)
 {
   std::stringstream terminationLogString;
   double heatflux = 0.0;
   vtkInterface->write_particle_track(branchMaxLengthPart, heatflux);
-  integrator->count_particle(triangle.entity_handle(), terminationState::MAXLENGTH, heatflux);
+  integrator->count_particle(particle.parent_entity_handle(), terminationState::MAXLENGTH,
+                             heatflux);
   terminationLogString << "Fieldline trace reached maximum length before intersection";
 }
 
@@ -884,7 +856,7 @@ ParticleSimulation::Execute_serial()
   std::vector<double> qvalues;
   setup_sources();
   double parallelProfilingStart = MPI_Wtime();
-  qvalues = loop_over_facets(start, end);
+  qvalues = loop_over_particles(start, end);
   double parallelProfilingEnd = MPI_Wtime();
   std::cout << "Parallel Compute Runtime = " << parallelProfilingEnd - parallelProfilingStart
             << std::endl;
@@ -899,12 +871,13 @@ ParticleSimulation::Execute_serial()
   std::vector<double> psiStart(target_num_facets());
   std::vector<double> bnList(target_num_facets());
   std::vector<std::vector<double>> normalList(target_num_facets());
-  for (int i = 0; i < listOfTriangles.size(); ++i)
-  {
-    psiStart[i] = listOfTriangles[i].get_psi();
-    bnList[i] = listOfTriangles[i].BdotN();
-    normalList[i] = listOfTriangles[i].get_normal();
-  }
+
+  // for (int i = 0; i < listOfTriangles.size(); ++i)
+  // {
+  //   psiStart[i] = listOfTriangles[i].get_psi();
+  //   bnList[i] = listOfTriangles[i].BdotN();
+  //   normalList[i] = listOfTriangles[i].get_normal();
+  // }
 
   attach_mesh_attribute("Heatflux", targetFacets, qvalues);
   attach_mesh_attribute("Psi Start", targetFacets, psiStart);
@@ -941,15 +914,15 @@ ParticleSimulation::Execute_padded_mpi()
     totalFacets = paddedTotalFacets;
   }
   int nFacetsPerProc = totalFacets / nprocs;
-  int startFacet = rank * nFacetsPerProc;
-  int endFacet = startFacet + nFacetsPerProc;
+  int startIndex = rank * nFacetsPerProc;
+  int endIndex = startIndex + nFacetsPerProc;
   int rootRank = 0;
 
   std::vector<double> qvalues;                  // qvalues buffer local to each processor
   std::vector<double> rootQvalues(totalFacets); // total qvalues buffer on root process for IO
   setup_sources();
   double parallelProfilingStart = MPI_Wtime();
-  qvalues = loop_over_facets(startFacet, endFacet); // perform main loop
+  qvalues = loop_over_particles(startIndex, endIndex); // perform main loop
 
   std::array<int, 5> particleStats = integrator->particle_stats();
   std::array<int, 5> totalParticleStats;
@@ -1034,12 +1007,12 @@ ParticleSimulation::Execute_mpi()
     displ += recieveCounts[i];
   }
 
-  int startFacet = displacements[rank];
-  int endFacet = startFacet + recieveCounts[rank];
+  int startIndex = displacements[rank];
+  int endIndex = startIndex + recieveCounts[rank];
 
   setup_sources();
   double parallelProfilingStart = MPI_Wtime();
-  qvalues = loop_over_facets(startFacet, endFacet); // perform main loop
+  qvalues = loop_over_particles(startIndex, endIndex); // perform main loop
   double endTime = MPI_Wtime();
 
   std::array<int, 5> particleStats = integrator->particle_stats();
@@ -1270,4 +1243,18 @@ ParticleSimulation::mesh_coord_transform(coordinateSystem coordSys)
       std::cout << "No coordinate system provided for mesh coordinate transform" << std::endl;
       break;
   }
+}
+
+void
+ParticleSimulation::write_particle_launch_positions(std::vector<double> & particleHeatfluxes)
+{
+  std::ofstream particleLaunchPosOut("particle_launch_positions.txt");
+  particleLaunchPosOut << "X Y Z Heatflux_per_particle" << std::endl;
+  for (int i = 0; i < listOfParticles.size(); ++i)
+  {
+    particleLaunchPosOut << listOfParticles[i].launchPos[0] << " "
+                         << listOfParticles[i].launchPos[1] << " "
+                         << listOfParticles[i].launchPos[2] << " " << particleHeatfluxes[i] << "\n";
+  }
+  particleLaunchPosOut << std::flush;
 }

--- a/src/aegis_lib/ParticleSimulation.cpp
+++ b/src/aegis_lib/ParticleSimulation.cpp
@@ -821,6 +821,10 @@ ParticleSimulation::print_particle_stats(std::array<int, 5> particleStats)
     LOG_WARNING << "Number of particles terminated upon reaching max tracking length = "
                 << particleStats[3];
     LOG_WARNING << "Number of padded null particles = " << particleStats[4];
+
+    int total = (particleLaunchPos == "mc") ? nParticlesPerFacet * target_num_facets()
+                                            : target_num_facets();
+
     LOG_WARNING << "Number of particles not accounted for = "
                 << (target_num_facets() * nParticlesPerFacet - particlesCounted);
   }

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -88,6 +88,7 @@ class ParticleSimulation : public AegisBase
   void init_geometry();
   std::vector<std::pair<double,double>> psiQ_values; // for l2 norm test
   int target_num_facets();
+  int num_particles_launched();
 
   protected:
 

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -150,6 +150,7 @@ class ParticleSimulation : public AegisBase
   unsigned int numberOfRayFireCalls = 0;
   unsigned int numberOfClosestLocCalls = 0;
   unsigned int iterationCounter=0;
+  int totalParticles = 0;
 
 
   // DAGMC variables

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -141,7 +141,7 @@ class ParticleSimulation : public AegisBase
   int dynamicBatchSize = 16;
   std::string coordinateConfig = "cart";
   bool workerProfiling = false;
-  bool workerDebug = false;
+  bool debugDynamicBatching = false;
   coordinateSystem coordSys = coordinateSystem::CARTESIAN; // default cartesian 
   bool noMidplaneTermination = false;
   int nParticlesPerFacet = 1; // Number of particles launched per facet

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -20,6 +20,7 @@
 #include <unordered_map>
 #include <time.h>
 #include <any>
+#include <numeric>
 
 #include <vtkCellArray.h>
 #include <vtkNew.h>
@@ -96,7 +97,7 @@ class ParticleSimulation : public AegisBase
   void dynamic_task_init();
   void implicit_complement_testing(); 
   moab::Range select_target_surface(); // get target surfaces of interest from aegis_settings.json
-  std::vector<double> loop_over_facets(int startFacet, int endFacet); // loop over facets in target surfaces
+  std::vector<double> loop_over_particles(int startFacet, int endFacet); // loop over particles across all target facets
   double monte_carlo_particle_launch(TriangleSource triangle);
   double fixed_particle_launch(TriangleSource triangle);
 
@@ -106,11 +107,11 @@ class ParticleSimulation : public AegisBase
   void polar_track();
   void flux_track();
   
-  terminationState cartesian_particle_track(TriangleSource &triangle, ParticleBase &particle); // loop over individual particle tracks
-  void terminate_particle_depositing(TriangleSource &triangle); // end particle track
-  void terminate_particle_shadow(TriangleSource &triangle); // end particle track
-  void terminate_particle_lost(TriangleSource &triangle); // end particle track
-  void terminate_particle_maxlength(TriangleSource &triangle); // end particle track
+  terminationState cartesian_particle_track(ParticleBase &particle); // loop over individual particle tracks
+  void terminate_particle_depositing(ParticleBase & particle); // end particle track
+  void terminate_particle_shadow(ParticleBase & particle); // end particle track
+  void terminate_particle_lost(ParticleBase & particle); // end particle track
+  void terminate_particle_maxlength(ParticleBase & particle); // end particle track
   void test_cyl_ray_fire(ParticleBase &particle);  
   
   
@@ -122,6 +123,7 @@ class ParticleSimulation : public AegisBase
   void attach_mesh_attribute(const std::string &tagName, moab::Range &entities, std::vector<std::vector<double>> &dataToAttach);
   
   void write_out_mesh(meshWriteOptions option, moab::Range rangeOfEntities = {});
+  void write_particle_launch_positions(std::vector<double> &particleHeatfluxes);
   void mesh_coord_transform(coordinateSystem coordSys);
   void select_coordinate_system();
   
@@ -142,8 +144,10 @@ class ParticleSimulation : public AegisBase
   coordinateSystem coordSys = coordinateSystem::CARTESIAN; // default cartesian 
   bool noMidplaneTermination = false;
   int nParticlesPerFacet = 1; // Number of particles launched per facet
+  bool writeParticleLaunchPos = false;
 
   std::vector<TriangleSource> listOfTriangles;
+  std::unordered_map<moab::EntityHandle,double> heatfluxMap;
   int totalNumberOfFacets = 0;
 
   std::vector<int> vectorOfTargetSurfs;
@@ -151,6 +155,7 @@ class ParticleSimulation : public AegisBase
   unsigned int numberOfClosestLocCalls = 0;
   unsigned int iterationCounter=0;
   int totalParticles = 0;
+  std::vector<ParticleBase> listOfParticles;
 
 
   // DAGMC variables

--- a/src/aegis_lib/Source.cpp
+++ b/src/aegis_lib/Source.cpp
@@ -116,13 +116,13 @@ Sources::set_heatflux_params(const std::shared_ptr<EquilData> & equilibrium,
 
   psi = fluxPos[0]; // store psi at particle start
   psid = psi + equilibrium->psibdry;
-  Q = equilibrium->omp_power_dep(psid, Bn, "exp"); // store Q at particle start
+  _totalHeatflux = equilibrium->omp_power_dep(psid, Bn, "exp"); // store Q at particle start
 }
 
 void
 Sources::update_heatflux(double newHeatflux)
 {
-  Q = newHeatflux;
+  _totalHeatflux = newHeatflux;
 }
 
 std::vector<double>
@@ -137,10 +137,16 @@ Sources::BdotN()
   return Bn;
 }
 
+void
+Sources::add_heatflux(double heatflux)
+{
+  _totalHeatflux += heatflux;
+}
+
 double
 Sources::heatflux()
 {
-  return Q;
+  return _totalHeatflux;
 }
 
 moab::EntityHandle

--- a/src/aegis_lib/Source.h
+++ b/src/aegis_lib/Source.h
@@ -23,6 +23,7 @@ class Sources : public AegisBase
   std::vector<double> launch_pos(); // return launch position on triangle
   double BdotN();
   double heatflux();
+  void add_heatflux(double heatflux);
   moab::EntityHandle entity_handle();
   double get_psi();
   std::vector<double> get_normal();
@@ -30,6 +31,7 @@ class Sources : public AegisBase
   protected:
   std::vector<double> launchPos;
   double Q = 0.0; // Q of triangle
+  double _totalHeatflux = 0.0;
   double psi = 0.0; // psi at particle start
   double Bn = 0.0; // B.n of Triangle
   moab::EntityHandle entityHandle;
@@ -48,7 +50,6 @@ class TriangleSource : public Sources
   std::vector<double> xyzA;
   std::vector<double> xyzB;
   std::vector<double> xyzC;
-
   double D;
 
 


### PR DESCRIPTION
Fairly self contained pull request for once. ** Main change is that MPI Dynamic load balancing is now done over particles rather than facets. **A couple of other minor changes have been made to some of the parameters passed around `ParticleSimulation` methods. 

Tests are still broken :(( 

Handler-Worker system should probably be abstracted out to its own class so that it can make use of internal members and a couple public facing methods in order to clean up the code within `ParticleSimulation`

Should be ready for a production environment (CSD3) in order to perform some scaling studies

Full changelist below:

Changelist
-
- Load balancing over particles vs triangles. This involved some changes to the main algorithm. Instead of storing a list of all the triangles within the particle simulation run that are looped through to do the main work. Now we store a list of particles which are looped through. `loop_over_facets` has been replaced by `loop_over_particles`. This means a few `ParticleSimulation` methods which had previously required `TriangleSource` as parameters, now require `ParticleBase` objects instead
- `ParticleSimulation::Loop_over_particles` loops through all of the particles and tracks them from launch to termination. It returns an std::vector of heatfluxes - if a particle's `terminationState == DEPOSITING` that heatflux will be non-zero. Otherwise a zero is returned. Finally in the main execution an extra reduction sum needs to be done for each facet to get the total heatflux accrued on a facet due to all of the particles launched
-  New level in config json `aegisParams { monteCarloParams }` that contains some settings for monte-carlo based particle simulation runs. Currently just two settings `number_of_particles_per_facet` and `write_particle_launch_positions`
- `ParticleBase` class now stores information about the `heatflux` it carries and the `moab::EntityHandle` of the facet it was launched from
