### PR TITLE
Ability to scale meshes in AEGIS

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -125,7 +125,7 @@
       "type": "cppdbg",
       "request": "launch",
       "program": "${workspaceRoot}/bin/aegis",
-      "args": ["aegis_settings.json"],
+      "args": ["mast.json"],
       "stopAtEntry": false,
       "cwd": "${workspaceRoot}/inres1",
       "environment": [],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,7 +83,12 @@
     "*.in": "cpp",
     "slist": "cpp",
     "*.txx": "cpp",
-    "*.ipp": "cpp"
+    "*.ipp": "cpp",
+    "compare": "cpp",
+    "concepts": "cpp",
+    "numbers": "cpp",
+    "ranges": "cpp",
+    "span": "cpp"
   },
 
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
         "options": {
           "cwd": "${workspaceRoot}/bld"
         },
-        "command": "cmake ../ -DDAGMC_DIR=/home/waqar/dagmc_bld/DAGMC"
+        "command": "cmake ../ -DDAGMC_DIR=/home/waqar/aegis-deps/DAGMC"
     },
     {
         "label": "clang-format-files",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ include_directories(externals/json/include)
 #include(${CMAKE_SOURCE_DIR}/cmake/SetBuildType.cmake)
 
 # Default to cpmpile with debugging symbols
-set(CMAKE_BUILD_TYPE RELEASE)
+set(CMAKE_BUILD_TYPE DEBUG)
 
 
 # Import VTK

--- a/inres1/aegis_settings.json
+++ b/inres1/aegis_settings.json
@@ -4,7 +4,7 @@
         "DAGMC": "inres1_shad.h5m",
         "step_size": 0.001,
         "max_steps": 100000,
-        "launch_pos": "random",
+        "launch_pos": "fixed",
   
         "monte_carlo_params":{
               "number_of_particles_per_facet":10,

--- a/inres1/mast.json
+++ b/inres1/mast.json
@@ -1,0 +1,43 @@
+{
+    "description": "inres1 test case to compare against SMARDDA",
+    "aegis_params":{
+        "DAGMC": "/home/waqar/moose-workshop/mast-dagmc.h5m",
+        "step_size": 0.001,
+        "max_steps": 1000000,
+        "launch_pos": "fixed",
+  
+        "monte_carlo_params":{
+              "number_of_particles_per_facet":1,
+              "write_particle_launch_positions":true
+        },
+  
+        "target_surfs": [79436,79437,79438,79439,79440,79441,79442,79443],
+	"mesh_units": "cm",
+	"write_mesh": "target",
+        "force_no_deposition": false,
+        "coordinate_system": "xyz",
+        "execution_type": "dynamic",
+  
+        "dynamic_batch_params":{
+            "batch_size":16,
+            "worker_profiling": false,
+        "debug":false
+        } 
+    },
+    "equil_params":{
+        "eqdsk": "/home/waqar/moose-workshop/equil_MAST.eqdsk",
+        "power_sol": 3.2e+06,
+	"r_outrbdry": 8.07385,
+        "lambda_q": 6.187,
+        "cenopt": 2,
+        "psiref": -2.1628794,
+        "rmove": 0.0,
+        "draw_equil_rz": false,
+        "draw_equil_xyz": false,
+        "print_debug_info": false
+    },
+    "vtk_params":{
+        "draw_particle_tracks": true
+    }
+   }
+  

--- a/src/aegis_lib/EquilData.cpp
+++ b/src/aegis_lib/EquilData.cpp
@@ -829,10 +829,12 @@ EquilData::b_field(const std::vector<double> & position, std::string startingFro
     zz = polarPosition[1];
   }
 
-  if (zr < rmin || zr > rmax || zz < zmin || zz > zmax)
-  {
-    return {};
-  }
+  double tolerance = 1e-9;
+  // check if out of bounds
+  if (zr < rmin - tolerance) return {};
+  if (zr > rmax + tolerance) return {};
+  if (zz < zmin - tolerance) return {};
+  if (zz > zmax + tolerance) return {};
 
   // evaluate psi and psi derivs at given (R,Z) coords
   alglib::spline2ddiff(psiSpline, zr, zz, zpsi, zdpdr, zdpdz, null);

--- a/src/aegis_lib/EquilData.cpp
+++ b/src/aegis_lib/EquilData.cpp
@@ -223,7 +223,7 @@ EquilData::read_eqdsk(std::string filename)
 
   // Fix for ITER eqdsks
 
-  OVERRIDE_ITER = true;
+  OVERRIDE_ITER = false;
 
   if (OVERRIDE_ITER == true)
   {

--- a/src/aegis_lib/ParticleSimulation.cpp
+++ b/src/aegis_lib/ParticleSimulation.cpp
@@ -438,7 +438,6 @@ ParticleSimulation::init_geometry()
   }
   DAG->moab_instance()->set_coords(&nodesList[0], nodesList.size(), nodeCoords.data());
   DAG->write_mesh("scaled.vtk", 1);
-  std::exit(1);
   
   totalNumberOfFacets = facetsList.size();
 
@@ -530,7 +529,7 @@ ParticleSimulation::setup_sources()
   std::vector<double> trianglePtsA(3), trianglePtsB(3), trianglePtsC(3);
 
   // Preallocate exactly num_particles_launched() elements
-  listOfParticles.resize(num_particles_launched());
+  listOfParticles.reserve(num_particles_launched());
 
   // Index-based modification
   size_t particleIndex = 0;

--- a/src/aegis_lib/ParticleSimulation.h
+++ b/src/aegis_lib/ParticleSimulation.h
@@ -59,6 +59,13 @@
 
 using namespace moab;
 
+enum class MeshUnits
+{
+  UNSET,
+  M,
+  CM,
+  MM
+};
 
 enum class meshWriteOptions
 {
@@ -131,7 +138,8 @@ class ParticleSimulation : public AegisBase
   void write_particle_launch_positions(std::vector<double> &particleHeatfluxes);
   void mesh_coord_transform(coordinateSystem coordSys);
   void select_coordinate_system();
-  
+  void scale_mesh(MeshUnits from);
+
   // Simulation config parameters
   std::string exeType = "dynamic";
   std::string dagmcInputFile; // no defaults because 
@@ -150,6 +158,9 @@ class ParticleSimulation : public AegisBase
   bool noMidplaneTermination = false;
   int nParticlesPerFacet = 1; // Number of particles launched per facet
   bool writeParticleLaunchPos = false;
+  MeshUnits meshDimension = MeshUnits::UNSET;
+  meshWriteOptions writeMesh = meshWriteOptions::TARGET;
+
 
   std::vector<TriangleSource> listOfTriangles;
   int totalNumberOfFacets = 0;
@@ -178,7 +189,7 @@ class ParticleSimulation : public AegisBase
   moab::EntityHandle implComplementVol; 
   double nextSurfDist = 0.0; // distance to next surface
   moab::EntityHandle intersectedFacet;
-  int rayOrientation = 1; // rays are fired along surface normals
+  int rayOrientation = -1; // rays are fired along surface normals
   double trackLength = 0.0;
 
   double startTime;

--- a/src/aegis_lib/Source.cpp
+++ b/src/aegis_lib/Source.cpp
@@ -102,8 +102,7 @@ Sources::set_heatflux_params(const std::shared_ptr<EquilData> & equilibrium,
 
   polarPos = CoordTransform::cart_to_polar(launchPos);
 
-  bField = equilibrium->b_field(polarPos, "forwards");
-
+  bField = equilibrium->b_field(polarPos, "polar");
   bField = equilibrium->b_field_cart(bField, polarPos[2]);
   double product = 0;
   for (int i = 0; i < 3; i++)


### PR DESCRIPTION
PR to add the capability to scale a DAGMC mesh by some uniform scaling factor after reading in. More information can be found in #43. 

So far this is just a minimal block added after reading in the mesh to test if it works. Tested on a MAST-U mesh in cm to scale down to m and it looks pretty good when viewing the mesh in Paraview. 

Will need to cleanup the code and I think I'll write it as a separate function rather than keeping it in this `ParticleSimulation::init_geoemtry()` function.